### PR TITLE
feat: close remaining project-structure audit gaps

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,13 @@
+name: Release Publish
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish_release:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 nolte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Closes the three gaps surfaced by the `project-structure` audit after PR #69 had already aligned the broader layout: a missing release-publish workflow, an absent top-level `tests/` slot, and the missing repository LICENSE. With these in place, every MUST and the LICENSE SHOULD from `spec/project/project-structure/` are satisfied.

## Changes

- Add `.github/workflows/release-publish.yml`: thin caller of `nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18`, `workflow_dispatch`-only trigger, `contents: write` — required by `spec/project/branching-model/` §Required GitHub workflows so the Draft → Published gate can run.
- Add `LICENSE` (MIT, copyright "nolte") — satisfies the SHOULD for a public repository.
- Add `tests/.gitkeep` — placeholder satisfying the spec's MUST for a top-level `tests/` directory; the repo itself ships no runtime code, so the slot documents the convention for future test assets.

## Linked issues

None

## Testing

- `task lint` — green (`check-yaml`, `end-of-file-fixer`, `trailing-whitespace` all pass).
- Audit re-run via `/nolte-shared:project-structure-apply` confirms all three items flip to `pass`.

## Risk / rollout notes

Low. The new `release-publish.yml` is `workflow_dispatch`-only and triggers nothing automatically; it merely makes the manual Draft → Published path runnable. `tests/.gitkeep` and `LICENSE` are inert additions. The new workflow pins `nolte/gh-plumbing@v1.1.18` while the four pre-existing release workflows still pin `v1.1.12`; Renovate aligns those on its next run.