### PR TITLE
docs: bootstrap project/goals.md and project/roadmap.md

### DIFF
--- a/project/goals.md
+++ b/project/goals.md
@@ -1,0 +1,37 @@
+# Vision
+
+`nolte/workstation` lets the `workstation-operator` bring up any developer
+machine — laptop, VM, future replacement — to an identical, reproducible state
+from a single chezmoi source tree. One `chezmoi init --apply` bootstraps the
+asdf-pinned CLI toolchain, a baseline git config, a curated zsh experience,
+the reusable Taskfile collection, and the pre-commit / cookiecutter / MkDocs
+virtualenvs needed for everyday work; `chezmoi update` keeps that state
+current as Renovate flows upstream releases through `develop`. Inside that
+environment, `downstream-tooling-consumers` (cookiecutter, editors,
+project-local `task` runs) find every dotfile, venv path and `$PATH` entry
+exactly where they expect it, so the workstation behaves the same across
+every machine that adopts it.
+
+## Outcomes
+
+- **O-1** — On a freshly provisioned machine, the operator runs
+  `chezmoi init --apply` once and reaches a complete developer environment
+  (asdf-pinned CLIs, zsh with the configured plugins, git baseline, MkDocs
+  and pre-commit virtualenvs) without follow-up manual installs.
+  _(audience: workstation-operator)_
+
+- **O-2** — On an existing machine, the operator runs `chezmoi update` and
+  receives the latest dotfile and tool-version state without breaking running
+  shells, in-flight project work, or already-cached venv state.
+  _(audience: workstation-operator)_
+
+- **O-3** — Across every machine that runs `chezmoi apply`, the resulting
+  `$HOME` layout (venv paths, the `~/.local/share/taskfile-collection/`
+  includes, the asdf-managed `$PATH`) is identical, so cookiecutter, editors,
+  and project-local `task` runs find what they expect without per-machine
+  adjustments. _(audience: downstream-tooling-consumers)_
+
+- **O-4** — A Renovate-driven tool, plugin or Action bump moves from
+  proposed PR to merged `develop` with a single auto-mergeable change, so the
+  maintainer keeps every pin current without manual CI workarounds.
+  _(audience: workstation-maintainer)_

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -1,0 +1,21 @@
+# Roadmap
+
+This file is the queue governed by `spec/project/roadmap/` (canonical-language
+spec at `spec/project/roadmap/en.md` in `nolte/claude-shared`). It lists every
+planned, in-flight or accepted change to `nolte/workstation`.
+
+- Detail-level invariants (`fine` vs `coarse`) are enforced by
+  `nolte-shared:roadmap-refine`.
+- Lifecycle changes — adds, retargets, status flips, MVP-flag flips — go
+  through `nolte-shared:roadmap-planner`; do not hand-edit items below in
+  another context.
+- Item IDs follow the monotonic `R-<n>` shape and are never reused, even
+  after deletion. The next ID for an addition is `R-1`; do not reset the
+  counter when items are removed.
+
+Phase headings (`## Phase 1 — …`) are documentation, not schema. The queue
+starts without phases; add them here when phases become useful.
+
+## Queue
+
+_(empty — items are added via `nolte-shared:roadmap-planner`)_


### PR DESCRIPTION
## Summary
- First-write of the planning pair declared by `spec/project/roadmap/` via `nolte-shared:roadmap-init`.
- `project/goals.md` — Vision paragraph for `nolte/workstation` plus four outcomes (`O-1`..`O-4`) framed as end-user benefits and cited against confirmed audience identifiers from `AUDIENCES.md` (`workstation-operator`, `downstream-tooling-consumers`, `workstation-maintainer`).
- `project/roadmap.md` — empty queue carrying the spec-mandated guard rails: monotonic `R-<n>` IDs that never reset, lifecycle edits owned by `nolte-shared:roadmap-planner`, detail-level invariants enforced by `nolte-shared:roadmap-refine`, phase headings declared documentation rather than schema.
- Unblocks the next planning skills: `feature-decompose` (for the verifying feature plus the rest of the feature corpus) and eventually `mission-define` (which needs both `goals.md` and at least one feature with an `acceptance-<n>` criterion).

## Test plan
- [ ] `task lint` (pre-commit) stays green for the two new files
- [ ] `task test` (Vale) stays green for the new prose
- [ ] Confirm every outcome resolves to an audience identifier present in `AUDIENCES.md`
- [ ] Confirm the empty-queue guard text in `project/roadmap.md` reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)