### PR TITLE
feat(portfolio): bootstrap project/portfolio.yml with capability and tech-stack

### DIFF
--- a/project/portfolio.yml
+++ b/project/portfolio.yml
@@ -1,0 +1,69 @@
+# Portfolio manifest for nolte/workstation.
+# Schema: spec/portfolio/portfolio-management/ §Capability inventory per repository
+# Audience references resolve against AUDIENCES.md at the repo root.
+
+capabilities:
+  - name: developer-workstation-provisioning
+    description: >-
+      A chezmoi source tree that provisions a developer workstation to an
+      identical, reproducible state from a single `chezmoi init --apply`:
+      asdf-pinned CLI tool versions, a baseline git config, a curated zsh
+      setup, the reusable Taskfile collection, and the pre-commit /
+      cookiecutter / MkDocs Python virtualenvs.
+    audience:
+      - workstation-operator
+      - downstream-tooling-consumers
+    status: active
+    rationale: >-
+      workstation is the single chezmoi source of truth for nolte's developer
+      machines; consolidating tool pins, dotfiles, and venvs here gives every
+      machine an identical $HOME layout and removes per-machine manual setup.
+    since: 2026-06-01
+
+# Repo-specific tech-stack layer over the inherited portfolio stack.
+# Schema: spec/portfolio/tech-stack/ §Entry schema, §Inheritance semantics.
+# chezmoi_config/ is delivered product content (target-machine tooling), not
+# this repository's own build stack, so its dot_tool-versions rows are excluded.
+tech_stack:
+  additions:
+    - name: chezmoi
+      kind: framework
+      group: build-tooling
+      role: >-
+        Dotfile and machine-state manager that renders this source tree and
+        applies it to target workstations via chezmoi init --apply / chezmoi
+        update; defines the repository's dot_/.tmpl/run_onchange_* layout.
+      status: active
+      lifecycle: all
+      version: 2.40.0
+      source_of_truth: .tool-versions
+
+    - name: python
+      kind: language
+      group: documentation
+      role: >-
+        Runtime for the MkDocs documentation build; provides mkdocs-material
+        via docs/requirements.txt for the repository's own docs site.
+      status: active
+      lifecycle: build
+      source_of_truth: docs/requirements.txt
+
+  overrides:
+    - name: claude-code
+      inherit: false
+      rationale: >-
+        workstation is a chezmoi source tree, not a Claude Code plugin host; it
+        ships no .claude-plugin/ and loads no skills or agents.
+
+    - name: claude-code-plugin
+      inherit: false
+      rationale: >-
+        workstation is not a Claude Code plugin source tree; it carries no
+        plugin/marketplace manifests and follows chezmoi layout conventions.
+
+    - name: markdownlint
+      inherit: false
+      rationale: >-
+        workstation does not wire markdownlint; its .pre-commit-config.yaml runs
+        only check-yaml, end-of-file-fixer, and trailing-whitespace, and there is
+        no .markdownlint* config.


### PR DESCRIPTION
## Summary

Bootstrap the portfolio manifest for nolte/workstation: one capability
(developer-workstation-provisioning) via the portfolio-audit Bootstrap, plus the
repo-specific tech_stack: layer via tech-stack-capture.

## Changes

- Add project/portfolio.yml declaring the capability developer-workstation-provisioning
  (status active; audiences workstation-operator, downstream-tooling-consumers).
- Add tech_stack.additions: chezmoi (framework / build-tooling / all) and python
  (language / documentation / build — MkDocs docs-build helper).
- Add tech_stack.overrides suppressing claude-code, claude-code-plugin, and
  markdownlint as inherited portfolio entries that do not apply to a chezmoi repo.

## Linked issues

None

## Testing

- Validate project/portfolio.yml parses as YAML and conforms to the tech-stack
  schema (kind/group/status/lifecycle enums, mandatory fields, override rules, no
  shadow violations) via a local Python YAML check — all checks pass.

## Risk / rollout notes

None — manifest/documentation only; no generated dotfiles or workstation behaviour
changes. The next portfolio-audit run from claude-shared picks up the new manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)