### PR TITLE
fix(ci): add workflow_dispatch to build-static-tests

### DIFF
--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -6,6 +6,11 @@ on:
     branches: [ "develop" ]
   schedule:
     - cron: '16 0 * * 1'
+  # Allow manually re-running the required checks against a branch tip.
+  # A GITHUB_TOKEN squash-merge does not re-trigger `push`, so the required
+  # `static / Static CI Tests` context never lands on the post-merge develop
+  # tip; workflow_dispatch lets the release pre-publish gate be satisfied.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Add a `workflow_dispatch` trigger to `build-static-tests.yaml` so the required `static / Static CI Tests` check can be re-run on demand against a branch tip.

## Changes

- Add `workflow_dispatch:` to `.github/workflows/build-static-tests.yaml` (alongside the existing `push` / `pull_request` / `schedule` triggers)

## Linked issues

None

## Testing

- `task lint` (pre-commit: check-yaml, end-of-file-fixer, trailing-whitespace) passes

## Risk / rollout notes

Low risk: adds a manual trigger only; no job logic changes. Motivation: a GITHUB_TOKEN squash-merge does not re-trigger `push`, so the required `static / Static CI Tests` context never lands on the post-merge `develop` tip, which structurally blocks the release pre-publish gate (`release-publish-trigger` gate 2d). `workflow_dispatch` lets the checks be re-run on `--ref develop` so the gate can be satisfied. This is the `workflow-health` §Known-platform-constraint (GITHUB_TOKEN no-cascade) remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)