### PR TITLE
fix(ci): pass required tag input to reusable-release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -2,6 +2,19 @@ name: Release Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: |
+          Tag to publish. MUST match an existing release-drafter draft on the
+          default branch. No "newest wins" heuristic.
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          When true, run every validation gate but do not flip draft=false.
 
 permissions:
   contents: write
@@ -9,5 +22,8 @@ permissions:
 jobs:
   publish_release:
     uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.19
+    with:
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ inputs.dry_run }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fix a `startup_failure` of `release-publish.yml`: the caller dispatched `reusable-release-publish.yml@v1.1.19` without the `tag` input that the reusable declares as required.

## Changes

- Declare `workflow_dispatch` inputs `tag` (required) and `dry_run` (optional) on `.github/workflows/release-publish.yml`
- Forward both to `reusable-release-publish.yml@v1.1.19` via `with:`

## Linked issues

None

## Testing

- `task lint` (pre-commit) passes
- Verified the reusable's `workflow_call` contract at `v1.1.19` requires `tag` (string, required) and accepts optional `dry_run` (boolean)

## Risk / rollout notes

Low risk: caller-wiring fix only, no job logic. Unblocks `release-publish-trigger` (the prior dispatch failed at startup because `tag` was missing). Note: with the default `GITHUB_TOKEN` (no portfolio App `app-id` configured) a published release still does not cascade to `release-cd-deliver-docs.yml` / `release-cd-refresh-master.yml` — that GITHUB_TOKEN cascade gap is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)