### PR TITLE
fix(ci): wire portfolio App token into release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -19,11 +19,20 @@ on:
 permissions:
   contents: write
 
+# When `vars.PORTFOLIO_APP_ID` is set, the reusable mints a short-lived
+# GitHub-App installation token from `secrets.PORTFOLIO_APP_PRIVATE_KEY` and
+# uses it for `gh release edit --draft=false`. App-authored release:published
+# events cascade to release-cd-refresh-master and release-cd-deliver-docs;
+# GITHUB_TOKEN-authored ones don't (see spec/project/workflow-health/
+# §Known platform constraints). When the variable is unset, the reusable
+# falls through to `secrets.token` (GITHUB_TOKEN) and the cascade gap remains.
 jobs:
   publish_release:
     uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.19
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Wire the portfolio GitHub App into `release-publish.yml` so that a published release is App-authored and its `release: published` event cascades to `release-cd-deliver-docs.yml` (docs → GitHub Pages) and `release-cd-refresh-master.yml` (main fast-forward). A `GITHUB_TOKEN`-authored release does not cascade.

## Changes

- Pass `app-id: ${{ vars.PORTFOLIO_APP_ID }}` to `reusable-release-publish.yml@v1.1.19`
- Pass `app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}` as a secret
- Follows the portfolio convention used by `nolte/gh-plumbing`'s own `release-publish.yml`

## Linked issues

None

## Testing

- `task lint` (pre-commit) passes
- Reviewed against `nolte/gh-plumbing`'s reference `release-publish.yml` and the `reusable-release-publish.yml@v1.1.19` input/secret contract

## Risk / rollout notes

Low risk and backwards-compatible: when `vars.PORTFOLIO_APP_ID` is unset, the reusable falls back to `secrets.token` (`GITHUB_TOKEN`) and publishing still works (without the cascade). To activate the cascade, the operator must set the repo/org variable `PORTFOLIO_APP_ID`, add the secret `PORTFOLIO_APP_PRIVATE_KEY`, and install the App on the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)