### PR TITLE
fix(ci): add workflow_dispatch to release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,9 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - develop
+  # A GITHUB_TOKEN squash-merge does not re-trigger `push`, so the draft is
+  # not refreshed after an automerged PR; allow a manual refresh on develop.
+  workflow_dispatch:
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
## Summary

Add a `workflow_dispatch` trigger to `release-drafter.yml` so the release draft can be regenerated on demand.

## Changes

- Add `workflow_dispatch:` to `.github/workflows/release-drafter.yml` (alongside the existing `push` trigger)

## Linked issues

None

## Testing

- `task lint` (pre-commit) passes

## Risk / rollout notes

Low risk: adds a manual trigger only. Motivation: GITHUB_TOKEN squash-merges (via automerge) do not re-trigger `push`, so the draft is never refreshed after an automerged PR. This is the same GITHUB_TOKEN no-cascade constraint addressed for `build-static-tests` (#76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)