### PR TITLE
feat(planning): author mission cascade (roadmap R-1, sprint 0001, feature F-1, mission)

### DIFF
--- a/project/features/one-command-provisioning.md
+++ b/project/features/one-command-provisioning.md
@@ -1,0 +1,53 @@
+---
+id: F-1
+title: One-command provisioning to a complete developer environment
+status: ready
+roadmap_item: R-1
+sprint: 1
+created: 2026-06-06
+ended: null
+verifies_sprint_value: acceptance-1
+consistency_check:
+  agent_version: manual-2026-06-06
+  findings:
+    - kind: clean
+      target: project/features/
+      resolution: proceed
+---
+
+## Description
+
+A `workstation-operator` provisions a fresh developer machine to a complete,
+ready-to-use state from the chezmoi source tree with a single command. After
+`chezmoi init --apply`, the operator has the asdf-pinned CLI toolchain on
+`$PATH`, the curated zsh experience, a baseline git configuration, and the
+MkDocs and pre-commit Python virtualenvs — without any follow-up manual install.
+A later `chezmoi update` keeps that state current, and the resulting `$HOME`
+layout is identical across every machine provisioned from the same source.
+
+## Acceptance criteria
+
+- [ ] **acceptance-1** On a freshly provisioned machine, `chezmoi init --apply` completes and yields a working developer environment (asdf-pinned CLIs on `$PATH`, zsh with the configured plugins, a baseline git config, and the MkDocs and pre-commit virtualenvs) with no follow-up manual install.
+- [ ] **acceptance-2** Re-running `chezmoi update` on an existing machine applies the latest dotfile and tool-version state without breaking running shells or in-flight project work.
+- [ ] **acceptance-3** Across two machines provisioned from the same source tree, the resulting `$HOME` layout (venv paths, the taskfile-collection includes, the asdf-managed `$PATH`) is identical.
+
+## Test hooks
+
+- **acceptance-1** — manual: provision a fresh VM, run `chezmoi init --apply nolte`, then verify the toolchain, zsh, git, and venvs — pending
+- **acceptance-2** — manual: run `chezmoi update` on a configured machine and confirm running shells and in-flight work survive — pending
+- **acceptance-3** — manual: diff the `$HOME` layout across two freshly provisioned machines — pending
+
+## Consistency notes
+
+Manual consistency pass performed by operator `nolte` on 2026-06-06 (the
+`feature-consistency-reviewer` agent fallback per the feature spec). This is the
+first feature under `project/features/`, so there is no overlapping or
+contradicting feature; the chezmoi source tree carries no already-implemented
+behaviour this feature would re-implement; and no spec decision constrains it.
+Finding recorded as `clean` / `proceed`.
+
+## Risks
+
+- The acceptance criteria are verified manually; there is no automated
+  provisioning smoke test yet. A container-image CI smoke test for acceptance-1
+  would harden the verification.

--- a/project/mission.md
+++ b/project/mission.md
@@ -1,0 +1,81 @@
+---
+mission_statement: nolte/workstation lets the workstation-operator bring any developer machine to an identical, reproducible state from a single chezmoi source tree, so every machine and the downstream tooling running on it behave the same.
+relevant_outcomes: [O-1, O-2, O-3]
+audiences: [workstation-operator, downstream-tooling-consumers, workstation-maintainer]
+verifies_via: F-1:acceptance-1
+time_bound:
+  kind: mvp_completion
+mvp_status: defining
+created: 2026-06-06
+revised_at: null
+---
+
+## Statement
+
+nolte/workstation lets the `workstation-operator` bring any developer machine to
+an identical, reproducible state from a single chezmoi source tree, so every
+machine — and the downstream tooling running on it — behaves the same.
+
+- **Specific** — a chezmoi source tree that provisions a complete developer
+  workstation (asdf-pinned CLIs, zsh, git baseline, reusable Taskfiles, and the
+  pre-commit / cookiecutter / MkDocs virtualenvs) for the audiences below.
+- **Measurable** — anchored in `verifies_via: F-1:acceptance-1`; when one
+  `chezmoi init --apply` on a fresh machine yields a working environment with no
+  follow-up manual install, the mission is observably achieved.
+- **Achievable** — the MVP is roadmap item `R-1` (one-command provisioning),
+  one sprint of hobby-scale work, building on the chezmoi source that already
+  exists in the repository.
+- **Relevant** — anchored in `relevant_outcomes: [O-1, O-2, O-3]` from
+  `project/goals.md`: one-command provisioning (O-1), non-breaking updates
+  (O-2), and an identical `$HOME` layout across machines (O-3). O-4
+  (Renovate-driven auto-merge) is a maintainer concern, supported but not
+  mission-bearing.
+- **Time-bound** — anchored in `time_bound: { kind: mvp_completion }`; the
+  mission is bound to the moment `mvp_status` reaches `achieved`, not a calendar
+  date.
+
+## Audiences
+
+### workstation-operator
+
+The operator runs `chezmoi init --apply` on a fresh machine and `chezmoi update`
+on an existing one. The MVP delivers them a single-command path from a bare
+machine to a complete, working developer environment, and a non-breaking update
+path that preserves running shells and in-flight work.
+
+### downstream-tooling-consumers
+
+Cookiecutter, editors, and project-local `task` runs expect every dotfile, venv
+path, and `$PATH` entry exactly where the source tree places it. The MVP
+delivers them an identical `$HOME` layout across every machine provisioned from
+the same source, so tooling behaves the same everywhere.
+
+### workstation-maintainer
+
+The maintainer keeps the source tree and its pins current. The MVP delivers them
+a reproducible provisioning path they can validate on a fresh machine; the
+Renovate-driven auto-merge loop (O-4) that further eases pin maintenance is
+supported but explicitly post-MVP.
+
+## Verification
+
+The mission is verified by feature [F-1 `one-command-provisioning`](features/one-command-provisioning.md),
+acceptance criterion **acceptance-1**, which reads verbatim:
+
+> On a freshly provisioned machine, `chezmoi init --apply` completes and yields
+> a working developer environment (asdf-pinned CLIs on `$PATH`, zsh with the
+> configured plugins, a baseline git config, and the MkDocs and pre-commit
+> virtualenvs) with no follow-up manual install.
+
+The feature carries `verifies_sprint_value: acceptance-1`, so Sprint 0001 — the
+sprint that contains F-1 — is the sprint that closes the mission's MVP. When that
+checkbox flips to checked (observed manually on a freshly provisioned machine),
+the mission's Measurable letter is satisfied.
+
+## Source
+
+- **Audience artefact:** [`AUDIENCES.md`](../AUDIENCES.md).
+- **Outcomes source:** [`project/goals.md`](goals.md), outcomes O-1, O-2, O-3.
+- **Verifying-feature source:** [`project/features/one-command-provisioning.md`](features/one-command-provisioning.md),
+  feature ID `F-1`, criterion `acceptance-1`.
+- **Author:** operator `nolte` via a manual `mission-define` pass, 2026-06-06.

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -18,4 +18,26 @@ starts without phases; add them here when phases become useful.
 
 ## Queue
 
-_(empty — items are added via `nolte-shared:roadmap-planner`)_
+<!-- Items are added by `roadmap-planner`. Do not edit by hand. -->
+
+### R-1 — One-command provisioning of a complete developer workstation
+
+```yaml
+id: R-1
+title: One-command provisioning of a complete developer workstation
+detail: fine
+outcomes: [O-1]
+target_sprint: 1
+mvp: true
+status: proposed
+```
+
+The first end-to-end provisioning path: a `workstation-operator` runs a single
+`chezmoi init --apply` on a fresh machine and reaches a complete, ready-to-use
+developer environment (asdf-pinned CLI toolchain, the curated zsh setup, a git
+baseline, and the MkDocs / pre-commit virtualenvs) without any follow-up manual
+install. This item carries the sprint-1 value-verifying feature.
+
+Intended features:
+
+- [ ] One-command provisioning to a complete developer environment

--- a/project/sprints/0001.md
+++ b/project/sprints/0001.md
@@ -1,0 +1,34 @@
+---
+number: 1
+status: planned
+started: null
+ended: null
+value_statement: "A workstation-operator brings a fresh machine to a complete, ready-to-use developer environment with a single `chezmoi init --apply`."
+artifact_ref: null
+last_commit: null
+roadmap_items:
+  - R-1
+features:
+  - F-1
+---
+
+## Goal
+
+At sprint close, a `workstation-operator` can take a freshly imaged machine and,
+with one `chezmoi init --apply`, reach a working developer environment — no
+manual tool installs, no hand-edited dotfiles. Success is the operator opening a
+new shell and finding the asdf-pinned toolchain, the configured zsh, the git
+baseline, and the MkDocs / pre-commit virtualenvs already in place.
+
+## Features
+
+- [F-1 one-command-provisioning](../features/one-command-provisioning.md) — ready
+
+## Out of scope
+
+- Renovate-driven auto-merge of tool/plugin bumps (roadmap outcome O-4) — a
+  maintainer concern, not part of the first provisioning value.
+
+## Review notes
+
+_(populated by `sprint-review` at closure)_


### PR DESCRIPTION
## Summary

Authors the planning cascade for `nolte/workstation` so it carries a spec-conformant `project/mission.md`, resolving Warning **W1** from the 2026-06-02 portfolio audit (nolte/claude-shared#263) — the render placeholder for workstation clears once this lands and the inventory is re-rendered.

All content is grounded in the existing `project/goals.md` (outcomes O-1..O-4); nothing is invented.

## Changes

- `project/roadmap.md` — add roadmap item **R-1** "One-command provisioning of a complete developer workstation" (`mvp: true`, outcome O-1, target sprint 1).
- `project/sprints/0001.md` — open sprint **0001** with the value statement "a workstation-operator brings a fresh machine to a complete environment with one `chezmoi init --apply`".
- `project/features/one-command-provisioning.md` — feature **F-1** decomposing R-1, three acceptance criteria, `verifies_sprint_value: acceptance-1`, manual consistency check recorded.
- `project/mission.md` — SMART mission with `verifies_via: F-1:acceptance-1`, `mvp_status: defining`, audiences from `AUDIENCES.md`.

## Linked issues

Refs nolte/claude-shared#263

## Testing

- All four frontmatter blocks parse as YAML; cross-references verified: roadmap R-1 ↔ sprint `roadmap_items` ↔ feature `roadmap_item`; sprint `features` ↔ feature `id`/`sprint`; mission `verifies_via` ↔ feature `verifies_sprint_value`/`acceptance-1`.

## Risk / rollout notes

Low — planning documentation only; no code change. `mvp_status` starts at `defining`; acceptance criteria are manually verified (no automated provisioning test harness yet, noted in the feature's Risks).