### PR TITLE
feat(project): author mission via roadmap → feature → mission cascade

### DIFF
--- a/project/features/clean-machine-provisioning.md
+++ b/project/features/clean-machine-provisioning.md
@@ -1,0 +1,110 @@
+---
+id: F-1
+title: Clean-machine provisioning reaches the complete developer environment
+status: draft
+roadmap_item: R-1
+sprint: null
+created: 2026-06-05
+ended: null
+verifies_sprint_value: acceptance-5
+consistency_check:
+  performed_at: 2026-06-05
+  agent_version: feature-consistency-reviewer@542b93f
+  findings:
+    - kind: prior-art
+      target: spec/containerised-provisioning-tests/en.md
+      resolution: proceed
+    - kind: clean
+      target: n/a
+      resolution: proceed
+---
+
+## Description
+
+On a freshly provisioned Linux machine, the `workstation-operator` runs
+`chezmoi init --apply https://github.com/nolte/workstation.git` exactly once and
+is left with a complete, ready-to-work developer environment: the asdf-pinned
+CLI toolchain on `$PATH`, the configured zsh experience, a rendered baseline git
+config, the reusable Taskfile collection, and the pre-commit / cookiecutter and
+MkDocs Python virtualenvs.
+
+No second command and no manual install step are needed to reach a working
+state. Re-running `chezmoi apply` on the already-provisioned machine changes
+nothing — the environment converges in a single run and stays converged.
+
+This feature asserts that user-visible end state. The mechanism that proves it
+inside a throwaway container is owned by `spec/containerised-provisioning-tests/`;
+this feature references that mechanism rather than redefining it.
+
+## Acceptance criteria
+
+- [ ] **acceptance-1** After a single `chezmoi init --apply` on a clean Linux
+  machine, every CLI pinned in `~/.tool-versions` resolves via
+  `asdf which <tool>` to an existing, executable path.
+- [ ] **acceptance-2** `~/.gitconfig`, `~/.tool-versions`, and `~/taskfile.yaml`
+  exist with rendered template values — the operator's git name/email
+  substituted, `~/.tool-versions` byte-matching
+  `chezmoi_config/dot_tool-versions`, and `~/taskfile.yaml` referencing the
+  `~/.local/share/taskfile-collection/` include path.
+- [ ] **acceptance-3** The `~/.venvs/development` and `~/.venvs/docs` virtualenvs
+  exist and contain at least `pre-commit` and `mkdocs-material` respectively.
+- [ ] **acceptance-4** The three external zsh plugins under
+  `~/.oh-my-zsh/custom/plugins/` and the `~/.local/share/taskfile-collection/`
+  checkout exist as non-empty git checkouts.
+- [ ] **acceptance-5** The environment is ready for work after that single run
+  with no follow-up manual install, and a second `chezmoi apply` is a no-op (no
+  `run_onchange_*` script re-fires, exit status zero).
+
+## Test hooks
+
+- **acceptance-1** — containerised provisioning Bats `@test` asserting
+  `asdf which <tool>` for every tool read from `chezmoi_config/dot_tool-versions`
+  (per `spec/containerised-provisioning-tests/`) — pending
+- **acceptance-2** — containerised provisioning Bats `@test` asserting the three
+  dotfiles exist with rendered values — pending
+- **acceptance-3** — containerised provisioning Bats `@test` asserting both
+  venvs contain their sample packages — pending
+- **acceptance-4** — containerised provisioning Bats `@test` asserting the
+  zsh-plugin and taskfile-collection checkouts are non-empty — pending
+- **acceptance-5** — containerised provisioning Bats `@test` asserting the second
+  `chezmoi apply` re-fires no `run_onchange_*` script — pending
+
+## Consistency notes
+
+The `feature-consistency-reviewer` agent (`@542b93f`, 2026-06-05) reviewed this
+feature against the three mandated surfaces and surfaced two findings, both
+resolved `proceed`. Neither is a `draft → ready` blocker (no `overlap` /
+`duplication`).
+
+**prior-art — `spec/containerised-provisioning-tests/en.md` — proceed.** The
+acceptance criteria restate that spec's §"Provisioning post-conditions" and every
+test hook cites it as the verification mechanism. This is the intended direction
+of dependency: the feature describes the user-visible "what the operator gets",
+the spec defines "how the container proves it". They are different artefact kinds
+on different layers and cannot subsume one another, so `merge-into` / `supersede`
+are wrong; the spec is a committed draft the feature deliberately builds on, so
+`revisit-after` does not apply. Recorded for audit completeness.
+
+**clean — proceed.** The feature corpus is empty (F-1 is the first feature), so
+no feature-corpus overlap is possible. The `chezmoi_config/` source surface was
+scanned for all five criteria — the `run_onchange_*` scripts, `dot_tool-versions`,
+`dot_gitconfig.tmpl`, the venv-prepare script, and `.chezmoiexternal.toml` are the
+provisioning *implementation* the feature legitimately asserts the end state of,
+not behaviour the feature re-implements. No spec MUST is contradicted.
+
+Soft observation (not a finding, not a `draft → ready` concern): the test hooks
+are all `pending` and reference Bats `@test` blocks that the container-test spec
+mandates but that do not yet exist under `tests/`. That is an `in_progress → done`
+hook-status concern, tracked by the containerised-provisioning-tests work, not a
+consistency concern.
+
+## Risks
+
+- The verification mechanism (containerised provisioning Bats tests) is specified
+  but not yet implemented, so all test hooks are `pending`. The feature cannot
+  reach `done` until that test surface exists; this couples F-1's closure to the
+  delivery of `spec/containerised-provisioning-tests/`.
+- `spec/project/project-structure/` is absent from this repo, so the source-root
+  resolution for the consistency check fell back to the `CLAUDE.md` convention
+  (`.chezmoiroot = chezmoi_config`). Sound for this repo today, but a future
+  project-structure spec would be the authoritative source-layout oracle.

--- a/project/mission.md
+++ b/project/mission.md
@@ -1,0 +1,85 @@
+---
+mission_statement: >-
+  nolte/workstation provisions a complete, reproducible developer environment
+  for the workstation-operator from a single `chezmoi init --apply`, so that the
+  operator — and the downstream-tooling-consumers running inside the resulting
+  $HOME — find every CLI, dotfile, virtualenv and $PATH entry in place with no
+  manual follow-up.
+relevant_outcomes: [O-1]
+audiences: [workstation-operator, downstream-tooling-consumers]
+verifies_via: F-1:acceptance-5
+time_bound:
+  kind: outcome
+  ref: O-1
+mvp_status: defining
+created: 2026-06-05
+revised_at: null
+---
+
+## Statement
+
+nolte/workstation provisions a complete, reproducible developer environment for
+the `workstation-operator` from a single `chezmoi init --apply`, so that the
+operator — and the `downstream-tooling-consumers` running inside the resulting
+`$HOME` — find every CLI, dotfile, virtualenv and `$PATH` entry in place with no
+manual follow-up.
+
+SMART decomposition:
+
+- **Specific** — the `mission_statement` frontmatter field: one-shot provisioning
+  of a complete developer environment for the named `workstation-operator` and
+  `downstream-tooling-consumers`.
+- **Measurable** — the `verifies_via` field (`F-1:acceptance-5`): when that
+  acceptance criterion is checked, the mission is measurably achieved.
+- **Achievable** — the MVP scope is being shaped (`mvp_status: defining`) around
+  roadmap item `R-1`, which decomposes into the mission-verifying feature `F-1`;
+  no roadmap item is flagged `mvp: true` yet, so the achievability bound is not
+  yet asserted on the queue.
+- **Relevant** — the `relevant_outcomes` field (`O-1`): the foundational
+  one-shot-provisioning outcome from `goals.md`.
+- **Time-bound** — the `time_bound` field (`{ kind: outcome, ref: O-1 }`): the
+  mission is bound to the achievement of outcome `O-1`, per the outcome-shaped
+  bound the mission spec inherits from the sibling sprint spec.
+
+## Audiences
+
+- **`workstation-operator`** — The operator brings up any developer machine —
+  laptop, VM, or a future replacement — to an identical, ready-to-work state by
+  running `chezmoi init --apply` exactly once. The MVP delivers the asdf-pinned
+  CLI toolchain on `$PATH`, the configured zsh experience, a rendered baseline
+  git config, the reusable Taskfile collection, and the pre-commit / cookiecutter
+  and MkDocs virtualenvs, with no second command and no manual install step. A
+  re-applied machine converges with no changes, so the operator trusts the setup
+  to be reproducible across every machine that adopts it.
+
+- **`downstream-tooling-consumers`** — Tools that run *inside* the provisioned
+  environment — cookiecutter against `~/.venvs/development`, editors reading
+  `~/.gitconfig`, and project-local `task` runs that include
+  `~/.local/share/taskfile-collection/` — inherit a stable `$HOME` layout from
+  the same single provisioning run. The MVP guarantees that the venv paths, the
+  dotfile locations, and the asdf-managed `$PATH` are present and identical right
+  after the operator's first apply, so these consumers find what they expect
+  without any per-machine adjustment.
+
+## Verification
+
+The mission is verified by feature `F-1`
+(`project/features/clean-machine-provisioning.md`), whose `verifies_sprint_value`
+points at `acceptance-5`. Criterion text, verbatim:
+
+> **acceptance-5** The environment is ready for work after that single run with
+> no follow-up manual install, and a second `chezmoi apply` is a no-op (no
+> `run_onchange_*` script re-fires, exit status zero).
+
+When that criterion is checked — exercised by the containerised provisioning
+tests specified in `spec/containerised-provisioning-tests/` — the mission is
+measurably achieved.
+
+## Source
+
+- **Audience artefact:** `AUDIENCES.md` (last-commit SHA
+  `459dc6a2fede8ce7e04dd8c8b9b5ecdebe066370` at time of writing).
+- **Goals consulted:** `project/goals.md` — outcome `O-1` (one-shot provisioning
+  reaches a complete developer environment).
+- **Authored by:** operator `nolte` via the `mission-define` skill, commit-pending
+  (P3 of the planning cascade tracked in `nolte/workstation#80`).

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -18,4 +18,23 @@ starts without phases; add them here when phases become useful.
 
 ## Queue
 
-_(empty — items are added via `nolte-shared:roadmap-planner`)_
+```yaml
+id: R-1
+title: One-shot provisioning reaches a complete developer environment
+detail: fine
+outcomes: [O-1]
+target_sprint: null
+mvp: false
+status: proposed
+```
+
+On a freshly provisioned machine, `chezmoi init --apply` runs once and leaves a
+complete, ready-to-work developer environment — the asdf-pinned CLI toolchain,
+the configured zsh experience, the baseline git config, and the pre-commit /
+cookiecutter / MkDocs virtualenvs — with no follow-up manual installs. This item
+delivers and verifies that clean-machine end state, grounding outcome **O-1**.
+
+Features:
+
+- [ ] Clean-machine `chezmoi init --apply` reaches the complete environment end
+  state _(verifying feature — carries `verifies_sprint_value`; authored in P2)_

--- a/spec/.spec-config.yml
+++ b/spec/.spec-config.yml
@@ -1,0 +1,3 @@
+canonical_language: en
+languages: [en, de]
+spec_root: spec

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,8 @@
+# Specifications
+
+| Slug | Title (en) | Title (de) | Status | Last updated |
+| --- | --- | --- | --- | --- |
+| [containerised-provisioning-tests](containerised-provisioning-tests/en.md) | Containerised Provisioning Tests | Containerisierte Provisionierungstests | draft | unversioned |
+| [project/audience-identification](project/audience-identification/en.md) | Audience Identification | Zielgruppen-Identifikation | draft | unversioned |
+| [project/feature](project/feature/en.md) | Project Feature | Projekt-Feature | draft | unversioned |
+| [project/mission](project/mission/en.md) | Project Mission | Projekt-Mission | draft | unversioned |

--- a/spec/containerised-provisioning-tests/de.md
+++ b/spec/containerised-provisioning-tests/de.md
@@ -1,0 +1,102 @@
+# Containerisierte Provisionierungstests
+
+Status: draft
+
+## Kontext
+
+Dieses Repository ist ein [chezmoi](https://www.chezmoi.io/)-Quellbaum, der Entwickler-Workstations provisioniert. Das eigentliche „Build-Artefakt" ist der Zustand, den `chezmoi init --apply https://github.com/nolte/workstation.git` auf einer Zielmaschine herstellt: eine befüllte `~/.tool-versions` mit asdf-verwalteten CLIs, getemplatete Dotfiles (`~/.gitconfig`, `~/taskfile.yaml`), zwei Python-Virtualenvs unter `~/.venvs/`, drei zsh-Plugins unter `~/.oh-my-zsh/custom/plugins/` und ein Checkout der geteilten Taskfile-Collection unter `~/.local/share/taskfile-collection/`.
+
+Die bestehende CI-Pipeline (`.github/workflows/build-static-tests.yaml`) deckt Prosa-Linting (Vale), pre-commit, Trivy und chain-bench ab. Keiner dieser Jobs übt den eigentlichen Provisionierungspfad aus — sie validieren die *Quellen*, nicht das *Ergebnis*. Dadurch können heute drei Klassen von Regressionen unbemerkt auf `develop` landen:
+
+- Eine in `chezmoi_config/dot_tool-versions` gebumpte Tool-Version hat kein funktionierendes asdf-Plugin oder kein passendes Release-Artefakt mehr.
+- Eine Änderung an einem der `run_onchange_*`-Skripte bricht die Installation auf einer frischen Maschine, obwohl die gerenderte Datei `check-yaml` noch besteht.
+- Eine Änderung an `.chezmoiexternal.toml` referenziert ein umgezogenes oder umbenanntes Upstream-Repo und bricht damit Neu-Bootstraps, ohne Maschinen zu beeinflussen, die das External bereits gecached haben.
+
+Da der einzig sichere Ort, das durchgehend zu üben, eine Wegwerf-Umgebung ist, MUSS der Testpfad in einem Container leben. Der Container ist die Grenze, die das `$HOME` der Entwickler-Maschine und das User-FS des GitHub-Runners davor schützt, von einem ausschließlich als Test gedachten chezmoi-Lauf verändert zu werden.
+
+## Ziele
+
+- Verifizieren, dass `chezmoi apply` gegen den Inhalt dieses Repos auf einer sauberen Linux-Umgebung den erwarteten On-Disk-Zustand erzeugt — nicht nur, dass die Templates rendern.
+- Die Verifikation automatisch laufen lassen bei jeder Änderung, die den Provisionierungspfad plausibel beeinflussen kann (push/PR auf `develop`, push auf `main`).
+- Upstream-Drift (asdf-Plugins, Release-Artefakte, externe Repos) in fester wöchentlicher Kadenz erkennen, ohne dass Code-Änderungen nötig sind.
+- Der Entwicklerin dieselbe Verifikation lokal über einen einzigen `task`-Aufruf bereitstellen, ohne zusätzliche Einrichtung jenseits einer vorhandenen Docker-Installation.
+- Alle Nebenwirkungen eines Testlaufs innerhalb des Containers halten; nichts auf Host oder Runner wird verändert.
+- Idempotenz nachweisen: Ein zweites `chezmoi apply` auf einem bereits provisionierten Stand MUSS ein No-Op sein.
+
+## Nicht-Ziele
+
+- Verifikation der macOS-Provisionierung. Das Repo ist heute Linux-fokussiert; ein macOS-Pfad bräuchte eine eigene Spec und einen Nicht-Container-Runner.
+- Performance-, Durchsatz- oder Wall-Clock-Benchmarks des Apply-Vorgangs.
+- Verifikation der *Inhalte* der `nolte/taskfiles`-Collection, die `.chezmoiexternal.toml` klont. Dieses Repo besitzt seine eigenen Tests.
+- Verifikation der Workflows `release-cd-deliver-docs.yml` oder `release-cd-refresh-master.yml`. Die betreffen Doc-Auslieferung und Release-Fast-Forward, nicht die Provisionierung.
+- Konkrete Dockerfile-Inhalte, exakte Shell-Skripte oder Assertion-Tool-Entscheidungen vorzuschreiben. Diese Spec definiert das *Was* und die *Randbedingungen*; der Implementierungs-PR macht das konkret.
+- `build-static-tests.yaml` ersetzen. Die neue Pipeline ist additiv — pre-commit, Vale, Trivy und chain-bench bleiben eigene Jobs.
+
+## Anforderungen
+
+- **MUSS [MUST]**
+  - Die gesamte Testausführung MUSS in einem Container stattfinden, der aus einem in dieses Repo eingecheckten `Dockerfile` gebaut wird (Vorschlagspfad: `tests/Dockerfile`). Das Base-Image MUSS ein gepinntes Ubuntu-LTS-Tag (oder ein Digest) sein, und der Pin MUSS für Renovate erkennbar sein, damit er zusammen mit dem übrigen Toolchain-Stand gebumpt wird.
+  - Der Container MUSS ausschließlich die minimal nötigen System-Voraussetzungen installieren, um `chezmoi`, `asdf` und `python` lauffähig zu machen. Jedes weitere in `chezmoi_config/dot_tool-versions` gelistete Tool MUSS *vom Provisionierungslauf selbst* installiert werden, nicht ins Image vorgebacken — sonst übte der Test gerade den Pfad nicht aus, den er zu prüfen vorgibt.
+  - Der Test-Entrypoint MUSS `chezmoi init` gegen den lokalen Working-Tree dieses Repos ausführen (nicht gegen einen Remote-Clone von GitHub), damit die Änderungen eines PR getestet werden, bevor sie auf `develop` existieren.
+  - Der Test-Entrypoint MUSS `chezmoi apply` einmal ausführen, die Nachbedingungen aus §„Provisionierungs-Nachbedingungen" prüfen, anschließend `chezmoi apply` ein *zweites* Mal ausführen und sichern, dass kein `run_onchange_*`-Skript erneut feuert und der Exit-Status null ist.
+  - Die vom Container konsumierte `chezmoi.toml` MUSS eine Testfixture unter `tests/` mit Dummy-Werten für `git_email` und `git_name` sein. Der Container DARF die `~/.config/chezmoi/chezmoi.toml` von Host oder Runner NICHT lesen.
+  - Der Container MUSS ohne `--privileged`, ohne Mount des Docker-Sockets und ohne Bind-Mount des Entwickler-`$HOME` oder irgendeines anderen User-Verzeichnisses außerhalb des Repo-Checkouts laufen. Das Repo-Checkout selbst KANN [MAY] read-only gemountet oder zur Build-Zeit per `COPY` ins Image gelegt werden, aber das `$HOME` im Container MUSS ein im Image frisch angelegtes Verzeichnis sein.
+  - Die neue Pipeline MUSS unter `.github/workflows/` angesiedelt sein und auf push auf `develop`, push auf `main`, Pull Requests gegen `develop` sowie auf einem wöchentlichen Schedule entsprechend dem bestehenden Static-Tests-Cron (`cron: '16 0 * * 1'`) laufen.
+  - Die Root-`Taskfile.yml` MUSS ein neues Target `test:container` bekommen, das *dasselbe* Image mit *demselben* Entrypoint baut und startet wie der Workflow. Lokale und CI-Läufe MÜSSEN sich diesen einen Code-Pfad teilen; eine Regression in einem MUSS sich ohne Anpassungen im anderen reproduzieren lassen.
+  - Der Platzhalter `tests/.gitkeep` MUSS in demselben PR entfernt werden, der die echten Testartefakte unter `tests/` einführt.
+  - Die Assertion-Schicht MUSS in [Bats](https://github.com/bats-core/bats-core) geschrieben sein. Jede `MUSS`-Nachbedingung aus §„Provisionierungs-Nachbedingungen" MUSS einem eigenen `@test`-Block entsprechen, damit Fehler einzeln pro Assertion gemeldet werden und nicht als ein einziger Shell-Exit. Die Bats-Version MUSS im Repo in einer für Renovate erkennbaren Form gepinnt sein (entweder als asdf-verwaltetes Plugin, das nur im Test-Image verwendet wird, oder als Distro-Paketversions-Pin im Dockerfile), damit die Test-Engine-Version im Gleichschritt mit der übrigen Toolchain gebumpt wird.
+  - Fehlerklassen MÜSSEN unterscheidbar sein. Ein fehlgeschlagener `@test`-Block (Assertion: `asdf which kubectl` löst nicht auf, `~/.venvs/docs` fehlt) erscheint als Bats-Test-Fehlschlag mit einem Gesamt-Exit ungleich null und Per-Test-Diagnose; ein fehlgeschlagener Image-Build, ein Netzwerkfehler beim Ziehen eines asdf-Plugins oder ein chezmoi-Crash im Entrypoint MUSS separat sichtbar werden (z. B. über einen anderen Exit-Code, eine andere Workflow-Step-Grenze oder einen klar markierten Log-Marker), damit eine rote Pipeline sofort sagt, welche Fehlerklasse zu triagieren ist.
+
+- **SOLLTE [SHOULD]**
+  - Das Dockerfile SOLLTE unter `tests/` neben Fixtures und Entrypoint-Skript liegen, damit die gesamte Testfläche ein Ordner ist.
+  - Der Base-Image-Pin SOLLTE ein Digest sein, kein floatendes Tag, damit ein Upstream-Image-Rebuild nicht stillschweigend das Verhalten zwischen zwei Läufen desselben Commits ändert.
+  - Die Pipeline SOLLTE die TAP-Ausgabe von Bats (oder das äquivalente Bats-native Pretty-Format) ins CI-Log schreiben und den TAP-Stream als Workflow-Artefakt hochladen, damit ein Fehler allein aus dem CI heraus debuggbar ist — jeder `@test` und die jeweils inspizierten Artefakte (Tool-Liste, Dotfile-Liste, Venv-Inhaltsstichprobe) tauchen namentlich im Log auf, ohne dass lokal nachgestellt werden muss.
+  - Jede `MUSS`-Assertion aus §„Provisionierungs-Nachbedingungen" SOLLTE unabhängig geübt werden, damit ein einzelner Fehlschlag den Rest nicht maskiert.
+  - Der Container SOLLTE auf `linux/amd64` laufen. Weitere Architekturen KÖNNEN [MAY] später ergänzt werden, sind aber von dieser Spec nicht gefordert.
+  - Der wöchentliche Cron-Lauf SOLLTE sein Ergebnis über denselben Benachrichtigungspfad melden wie andere scheduled Jobs in diesem Repo (keine Sonderfall-Alarmierung).
+
+- **KANN [MAY]**
+  - Die Pipeline KANN Container-Image-Layer im GitHub-Actions-Cache zwischenspeichern, sofern der Cache-Key den Dockerfile-Hash mit einschließt, damit eine Dockerfile-Änderung einen Rebuild erzwingt.
+  - Die Pipeline KANN einen Smoke-Schritt enthalten, der nach dem Apply ein repräsentatives `task` aus `~/taskfile.yaml` ausführt, um zu verifizieren, dass das getemplatete Taskfile seine Includes gegen `~/.local/share/taskfile-collection/` auflöst.
+  - Folge-PRs KÖNNEN die Spec um eine Distro-Matrix erweitern (z. B. Ubuntu LTS + Fedora) — außerhalb des Scopes hier, aber die Implementierung SOLLTE eine Matrix-Erweiterung nicht schwerer machen als ein Tausch des Base-Images.
+
+## Provisionierungs-Nachbedingungen
+
+Der folgende On-Disk-Zustand im Container ist das, was ein grüner Lauf assertet. Der Implementierungs-PR übersetzt das in konkrete Checks; die Spec fixiert den Vertrag.
+
+- Für jedes in `chezmoi_config/dot_tool-versions` gelistete Tool MUSS `asdf which <tool>` einen existierenden, ausführbaren Pfad auflösen. Die Tool-Liste der Assertions wird aus der Datei gelesen, nicht im Test hartkodiert — Drift in `dot_tool-versions` darf keine Parallelpflege der Assertions erfordern.
+- `~/.gitconfig` MUSS existieren und MUSS die Dummy-Werte `git_email` / `git_name` aus der Test-`chezmoi.toml`-Fixture enthalten (damit nachgewiesen ist, dass die Template-Substitution wirklich lief).
+- `~/.tool-versions` MUSS existieren und MUSS byteidentisch zu `chezmoi_config/dot_tool-versions` sein.
+- `~/taskfile.yaml` MUSS existieren und MUSS `~/.local/share/taskfile-collection/` irgendwo in seinem Include-Graphen referenzieren.
+- `~/.venvs/development/` und `~/.venvs/docs/` MÜSSEN als gültige Python-Virtualenvs existieren. Jedes MUSS mindestens ein Stichproben-Paket aus dem zugehörigen `requirements-*.txt` enthalten: `pre-commit` für development, `mkdocs-material` für docs.
+- Die drei in `.chezmoiexternal.toml` deklarierten zsh-Plugin-Verzeichnisse MÜSSEN als nicht-leere Git-Checkouts unter `~/.oh-my-zsh/custom/plugins/` existieren.
+- `~/.local/share/taskfile-collection/` MUSS als nicht-leerer Git-Checkout existieren.
+- Jedes `run_onchange_*`-Skript in `chezmoi_config/` MUSS beim ersten Apply einen beobachtbaren Seiteneffekt hinterlassen haben (asdf-Plugins ergänzt, `asdf install` ausgeführt, Venvs angelegt). Das zweite Apply DARF sie NICHT erneut ausführen; der Test prüft das über die `chezmoi apply --verbose`-Ausgabe oder ein äquivalentes chezmoi-natives Signal.
+
+## Verhältnis zu bestehenden Repo-Konventionen
+
+- `CLAUDE.md` nennt zwei strukturelle Tatsachen, die diese Spec übernimmt, ohne sie zu wiederholen: die `.chezmoiroot = chezmoi_config`-Indirektion und die bewusste Duplizierung von `requirements-development.txt` / `requirements-mkdocs.txt` zwischen `docs/` (vom Docs-Delivery-Workflow genutzt) und `chezmoi_config/` (zur Apply-Zeit genutzt). Der Test MUSS die `chezmoi_config/`-Kopien konsumieren, da das die Dateien sind, die `chezmoi apply` tatsächlich installiert.
+- Alle `.github/workflows/`-Dateien in diesem Repo sind dünne Wrapper über `nolte/gh-plumbing`-Reusable-Workflows, an unveränderliche Release-Tags gepinnt und gemeinsam von Renovate gebumpt. Der neue Provisionierungs-Test-Workflow SOLLTE diesem Muster folgen *nur falls* es upstream einen passenden Reusable Workflow gibt; andernfalls KANN er ein in sich geschlossener Workflow sein, mit der expliziten Anerkennung, dass er damit der erste Non-Reusable-Workflow in diesem Repo ist.
+
+## Akzeptanzkriterien
+
+- [ ] `tests/` enthält ein `Dockerfile`, eine Test-`chezmoi.toml`-Fixture und ein Entrypoint-Skript. `tests/.gitkeep` ist entfernt.
+- [ ] Ein neuer Workflow unter `.github/workflows/` startet den Container auf push/PR auf `develop`, push auf `main` und auf dem Cron-Schedule `16 0 * * 1`.
+- [ ] Die Root-`Taskfile.yml` stellt `task test:container` bereit, das dasselbe Image und denselben Entrypoint baut und startet wie der Workflow.
+- [ ] Ein sauberer lokaler Aufruf von `task test:container` endet auf dem aktuellen `develop`-Tip mit Exit-Code 0.
+- [ ] Während eines grünen Laufs ist `asdf which <tool>` für jedes in `chezmoi_config/dot_tool-versions` gelistete Tool erfolgreich.
+- [ ] Während eines grünen Laufs existieren `~/.gitconfig`, `~/.tool-versions` und `~/taskfile.yaml`; `~/.gitconfig` enthält die Dummy-Fixture-Werte; `~/.tool-versions` ist byteidentisch zu `chezmoi_config/dot_tool-versions`.
+- [ ] Während eines grünen Laufs enthält `~/.venvs/development/` `pre-commit` und `~/.venvs/docs/` `mkdocs-material`.
+- [ ] Während eines grünen Laufs existieren die drei zsh-Plugin-Verzeichnisse unter `~/.oh-my-zsh/custom/plugins/` und `~/.local/share/taskfile-collection/` als nicht-leere Git-Checkouts.
+- [ ] Die Assertion-Suite liegt unter `tests/*.bats`, jeder `MUSS`-Eintrag aus §„Provisionierungs-Nachbedingungen" mappt auf genau einen `@test`-Block, und ein einzelner fehlgeschlagener `@test` überspringt die übrigen Assertions nicht.
+- [ ] Ein zweites direkt nachfolgendes `chezmoi apply` endet mit Exit-Code 0 und löst keine erneute Ausführung der `run_onchange_*`-Skripte aus.
+- [ ] Der Container-Lauf bindet kein Host-`$HOME` ein, verlangt kein `--privileged` und mountet keinen Docker-Socket.
+- [ ] `build-static-tests.yaml` läuft weiterhin unverändert auf denselben Triggern; nichts in der neuen Pipeline ersetzt oder kurzschließt deren Jobs.
+- [ ] Eine bewusst kaputtmachende Änderung an `chezmoi_config/dot_tool-versions` (z. B. eine nicht existierende Tool-Version) lässt die neue Pipeline fehlschlagen; das Zurücknehmen der Änderung macht sie wieder grün.
+- [ ] Der Base-Image-Pin und der Bats-Versions-Pin tauchen beide im Renovate-Dashboard auf, und Update-PRs für beide lassen sich von Renovate ohne manuelle Konfig-Eingriffe öffnen.
+
+## Offene Fragen
+
+- Soll das Image gebaut und nach GHCR gepusht werden, damit der Cron-Job und der Per-PR-Job es teilen können, oder in jedem Job neu gebaut? Trade-off ist Registry-Pflege gegen Build-Zeit.
+- Ist beim zweiten Apply das Parsen von `chezmoi apply --verbose` zuverlässig genug, um die erneute Ausführung von `run_onchange_*`-Skripten zu erkennen, oder brauchen wir ein chezmoi-natives Signal (z. B. Vergleich von State-Hashes)? Das beeinflusst, ob der Test von einem CLI-Ausgabeformat abhängt, das sich zwischen chezmoi-Releases ändern kann.
+- Reicht eine Single-Distro-Baseline (Ubuntu LTS) für den Anfang, oder sollte die erste Iteration bereits eine zweite Distro enthalten, um Ubuntu-spezifische Drift zu verhindern? Aktuelle Entscheidung: erst Single-Distro, Matrix später — nach den ersten drei Monaten grüner Läufe neu bewerten.

--- a/spec/containerised-provisioning-tests/en.md
+++ b/spec/containerised-provisioning-tests/en.md
@@ -1,0 +1,102 @@
+# Containerised Provisioning Tests
+
+Status: draft
+
+## Context
+
+This repository is a [chezmoi](https://www.chezmoi.io/) source tree that provisions developer workstations. Its real "build artefact" is the state produced on a target machine by `chezmoi init --apply https://github.com/nolte/workstation.git`: a populated `~/.tool-versions` with asdf-managed CLIs, templated dotfiles (`~/.gitconfig`, `~/taskfile.yaml`), two Python virtualenvs under `~/.venvs/`, three zsh plugins under `~/.oh-my-zsh/custom/plugins/`, and a checkout of the shared taskfile collection under `~/.local/share/taskfile-collection/`.
+
+The existing CI pipeline (`.github/workflows/build-static-tests.yaml`) covers prose linting (Vale), pre-commit, Trivy, and chain-bench. None of these exercise the actual provisioning path — they validate the *sources*, not the *result*. As a consequence, three classes of regression can land unnoticed on `develop` today:
+
+- A bumped tool version in `chezmoi_config/dot_tool-versions` no longer has a working asdf plugin or release artefact.
+- A change to one of the `run_onchange_*` scripts breaks installation on a clean machine, even though the rendered file still passes `check-yaml`.
+- A change to `.chezmoiexternal.toml` references a moved or renamed upstream repo, breaking new-machine bootstraps without affecting machines that already have the external cached.
+
+Because the only safe place to exercise this end-to-end is a throwaway environment, the test path must live inside a container. The container is the boundary that protects the developer's host `$HOME` and the GitHub-hosted runner's user FS from being mutated by a chezmoi run intended only as a test.
+
+## Goals
+
+- Verify that `chezmoi apply` against the contents of this repo produces the expected on-disk state on a clean Linux environment — not just that the templates render.
+- Make the verification automatic on every change that can plausibly affect the provisioning path (push/PR to `develop`, push to `main`).
+- Catch upstream drift (asdf plugins, release artefacts, external repos) on a fixed weekly cadence without code changes.
+- Give a developer the exact same verification locally via a single `task` invocation, with no extra setup beyond having Docker.
+- Keep all side effects of a test run inside the container; nothing on the host or runner is mutated.
+- Assert idempotency: a second `chezmoi apply` on an already-provisioned state must be a no-op.
+
+## Non-Goals
+
+- macOS provisioning verification. The repo is Linux-focused today; a macOS path would need a separate spec and a non-container runner.
+- Performance, throughput, or wall-clock benchmarks of the apply process.
+- Verifying the *contents* of the `nolte/taskfiles` collection that `.chezmoiexternal.toml` clones. That repo owns its own tests.
+- Verifying the `release-cd-deliver-docs.yml` or `release-cd-refresh-master.yml` workflows. Those concern documentation delivery and release fast-forwarding, not provisioning.
+- Prescribing concrete Dockerfile contents, exact shell scripts, or assertion-tool choices. This spec defines *what* must be verified and *under which constraints*; the implementation PR makes those concrete.
+- Replacing `build-static-tests.yaml`. The new pipeline is additive — pre-commit, Vale, Trivy, and chain-bench remain their own jobs.
+
+## Requirements
+
+- **MUST**
+  - All test execution MUST happen inside a container built from a `Dockerfile` checked into this repo (proposed path: `tests/Dockerfile`). The base image MUST be a pinned Ubuntu LTS tag (or a digest), and the pin MUST be discoverable by Renovate so it is bumped together with the rest of the toolchain.
+  - The container MUST install only the minimal system prerequisites needed to run `chezmoi`, `asdf`, and `python`. Every other tool listed in `chezmoi_config/dot_tool-versions` MUST be installed *by the provisioning run itself*, not pre-baked into the image — otherwise the test would not exercise the path it claims to cover.
+  - The test entrypoint MUST run `chezmoi init` against the local working tree of this repo (not a remote clone of GitHub) so a PR's changes are tested before they exist on `develop`.
+  - The test entrypoint MUST run `chezmoi apply` a first time, assert the post-conditions in §"Provisioning post-conditions", then run `chezmoi apply` a *second* time and assert that no `run_onchange_*` script fired again and that exit status is zero.
+  - The `chezmoi.toml` consumed by the container MUST be a test fixture stored under `tests/` with dummy values for `git_email` and `git_name`. The container MUST NOT read `~/.config/chezmoi/chezmoi.toml` from the host or runner.
+  - The container MUST run without `--privileged`, without mounting the Docker socket, and without bind-mounting the developer's `$HOME` or any user-owned directory outside the repo checkout. The repo checkout itself MAY be mounted read-only or `COPY`'d in at build time, but the container's `$HOME` MUST be a fresh directory created inside the image.
+  - The new pipeline MUST be wired into `.github/workflows/` so it runs on push to `develop`, push to `main`, pull requests targeting `develop`, and a weekly schedule matching the existing static-tests cron (`cron: '16 0 * * 1'`).
+  - The root `Taskfile.yml` MUST gain a `test:container` target that builds and runs the *same* image with the *same* entrypoint as the workflow uses. Local and CI runs MUST share that single code path; a regression in one MUST be reproducible in the other without changes.
+  - The placeholder `tests/.gitkeep` MUST be removed in the same PR that introduces real test artefacts under `tests/`.
+  - The assertion layer MUST be written in [Bats](https://github.com/bats-core/bats-core). Each `MUST`-level post-condition in §"Provisioning post-conditions" MUST correspond to its own `@test` block, so failures are reported one-per-assertion rather than as a single shell exit. The Bats version MUST be pinned in the repo in a Renovate-discoverable form (either as an asdf-managed plugin used only inside the test image, or as a distro-package version pin in the Dockerfile), so the test-engine version is bumped in lockstep with the rest of the toolchain.
+  - Test failure modes MUST be distinguishable from infrastructure failure. A failed `@test` block (assertion: `asdf which kubectl` doesn't resolve, `~/.venvs/docs` missing) surfaces as a Bats test failure with a non-zero overall exit and per-test diagnostics; a failed image build, a network error pulling an asdf plugin, or a chezmoi crash inside the entrypoint MUST surface separately (e.g. via a distinct exit code, a distinct workflow step boundary, or a clearly tagged log marker) so a red pipeline immediately tells the operator which failure class to triage.
+
+- **SHOULD**
+  - The Dockerfile SHOULD live under `tests/` alongside the fixtures and entrypoint script so the whole test surface is one folder.
+  - The base image pin SHOULD be a digest, not a floating tag, so an upstream image rebuild cannot silently change behaviour between two runs of the same commit.
+  - The pipeline SHOULD emit Bats' TAP output (or the equivalent Bats-native pretty format) into the CI log and SHOULD upload the TAP stream as a workflow artefact, so a failure is debuggable from CI alone — every `@test` and the artefacts it inspected (tool list, dotfile list, venv contents sample) appear by name in the log without rerunning locally.
+  - Each `MUST`-level assertion in §"Provisioning post-conditions" SHOULD be exercised independently so a single failure does not mask the rest.
+  - The container SHOULD be runnable on `linux/amd64`. Additional architectures MAY be added later but are not required by this spec.
+  - The weekly cron run SHOULD post its result through the same notification path as other scheduled jobs in this repo (no special-case alerting).
+
+- **MAY**
+  - The pipeline MAY cache the container image layers in the GitHub Actions cache, provided the cache key incorporates the Dockerfile hash so a Dockerfile change forces a rebuild.
+  - The pipeline MAY include a smoke step that runs a representative `task` from `~/taskfile.yaml` after apply, to verify that the templated Taskfile resolves its includes against `~/.local/share/taskfile-collection/`.
+  - Future PRs MAY extend the spec with a distro matrix (e.g. Ubuntu LTS + Fedora) — out of scope here, but the implementation SHOULD NOT make a matrix harder than swapping the base image.
+
+## Provisioning post-conditions
+
+The following on-disk state inside the container is what a successful run asserts. The implementation PR turns this into concrete checks; the spec fixes the contract.
+
+- For every tool listed in `chezmoi_config/dot_tool-versions`, `asdf which <tool>` MUST resolve to a path that exists and is executable. The list of tools to assert is read from the file, not hard-coded in the test — drift in `dot_tool-versions` must not require a parallel update of the assertions.
+- `~/.gitconfig` MUST exist and MUST contain the dummy `git_email` / `git_name` values from the test `chezmoi.toml` fixture (proving template substitution actually ran).
+- `~/.tool-versions` MUST exist and MUST match the bytes of `chezmoi_config/dot_tool-versions`.
+- `~/taskfile.yaml` MUST exist and MUST reference `~/.local/share/taskfile-collection/` somewhere in its include graph.
+- `~/.venvs/development/` and `~/.venvs/docs/` MUST exist as valid Python virtualenvs. Each MUST contain at least one sample package from its respective `requirements-*.txt`: `pre-commit` for development, `mkdocs-material` for docs.
+- The three external zsh plugin directories declared in `.chezmoiexternal.toml` MUST exist as non-empty git checkouts under `~/.oh-my-zsh/custom/plugins/`.
+- `~/.local/share/taskfile-collection/` MUST exist as a non-empty git checkout.
+- Each `run_onchange_*` script in `chezmoi_config/` MUST have left an observable side effect on the first apply (asdf plugins added, asdf install completed, venvs created). The second apply MUST NOT re-run them, which the test verifies via the `chezmoi apply --verbose` output or an equivalent chezmoi-native signal.
+
+## Relationship to existing repository conventions
+
+- `CLAUDE.md` calls out two structural facts that this spec inherits without restating them: the `.chezmoiroot = chezmoi_config` indirection, and the deliberate duplication of `requirements-development.txt` / `requirements-mkdocs.txt` between `docs/` (used by the docs-delivery workflow) and `chezmoi_config/` (used at apply time). The test MUST consume the `chezmoi_config/` copies, since those are what `chezmoi apply` actually installs.
+- All `.github/workflows/` files in this repo are thin wrappers over `nolte/gh-plumbing` reusable workflows, pinned to immutable release tags and bumped by Renovate together. The new provisioning-test workflow SHOULD follow the same pattern *only if* a suitable reusable workflow exists upstream; otherwise it MAY be a self-contained workflow, with the explicit acknowledgement that it is the first non-reusable workflow in this repo.
+
+## Acceptance Criteria
+
+- [ ] `tests/` contains a `Dockerfile`, a test `chezmoi.toml` fixture, and an entrypoint script. `tests/.gitkeep` is removed.
+- [ ] A new workflow under `.github/workflows/` runs the container on push/PR to `develop`, push to `main`, and the cron schedule `16 0 * * 1`.
+- [ ] The root `Taskfile.yml` exposes `task test:container`, which builds and runs the same image and entrypoint as the workflow.
+- [ ] A clean local invocation of `task test:container` exits 0 on the current `develop` tip.
+- [ ] During a green run, `asdf which <tool>` succeeds for every tool listed in `chezmoi_config/dot_tool-versions`.
+- [ ] During a green run, `~/.gitconfig`, `~/.tool-versions`, and `~/taskfile.yaml` exist; `~/.gitconfig` contains the dummy fixture values; `~/.tool-versions` is byte-identical to `chezmoi_config/dot_tool-versions`.
+- [ ] During a green run, `~/.venvs/development/` contains `pre-commit` and `~/.venvs/docs/` contains `mkdocs-material`.
+- [ ] During a green run, the three zsh plugin directories under `~/.oh-my-zsh/custom/plugins/` and `~/.local/share/taskfile-collection/` exist as non-empty git checkouts.
+- [ ] The assertion suite lives under `tests/*.bats`, every `MUST`-level entry in §"Provisioning post-conditions" maps to exactly one `@test` block, and a single failing `@test` does not skip the remaining assertions.
+- [ ] A second consecutive `chezmoi apply` exits 0 and triggers no `run_onchange_*` re-execution.
+- [ ] The container run does not bind-mount the host `$HOME`, does not require `--privileged`, and does not mount the Docker socket.
+- [ ] `build-static-tests.yaml` still runs unchanged on the same triggers; nothing in the new pipeline replaces or short-circuits its jobs.
+- [ ] A deliberate breaking change in `chezmoi_config/dot_tool-versions` (e.g. a non-existent tool version) makes the new pipeline fail; reverting it makes it green again.
+- [ ] The base image pin and the Bats version pin both appear in Renovate's dashboard, and update PRs for either can be opened by Renovate without manual config tweaks.
+
+## Open Questions
+
+- Should the image be built and pushed to GHCR for sharing between the cron job and the per-PR job, or rebuilt from scratch in each job? The trade-off is registry maintenance versus build time.
+- For the second apply, is `chezmoi apply --verbose` parsing reliable enough to detect re-execution of `run_onchange_*` scripts, or do we need a chezmoi-native marker (e.g. comparing state hashes)? This influences whether the test depends on a CLI output format that could change between chezmoi releases.
+- Is a single-distro (Ubuntu LTS) baseline enough, or should the first iteration already include a second distro to prevent ubuntu-specific drift? Current decision: single-distro now, matrix later — revisit after the first three months of green runs.

--- a/spec/project/audience-identification/de.md
+++ b/spec/project/audience-identification/de.md
@@ -1,0 +1,65 @@
+# Zielgruppen-Identifikation
+
+Status: draft
+
+## Kontext
+<!-- Warum existiert diese Spec? Welches Problem, welcher Bedarf oder welche Einschränkung treibt sie? -->
+
+Software-Module und Projekte werden von mehreren Zielgruppen konsumiert, betrieben, eingeschränkt oder beobachtet — Nutzer, Betreiber, nachgelagerte Integratoren, Maintainer, Security, Compliance, Business-Stakeholder, indirekt betroffene Endnutzer und mehr. Ohne ein diszipliniertes Verfahren, die zutreffenden Zielgruppen für einen *abgesteckten Kontext* (ein konkretes Modul, einen Service, eine Bibliothek oder ein Projekt) zu ermitteln, werden Entscheidungen über Dokumentationstiefe, API-Oberfläche, Release-Taktung, SLAs und Sicherheitslage gegen die privaten Annahmen der Autoren statt gegen die tatsächliche Zielgruppen-Menge getroffen. Diese Spec definiert ein wiederholbares Verfahren, mit dem sich die Zielgruppen eines abgesteckten Kontexts ermitteln und charakterisieren lassen, damit nachgelagerte Artefakte (READMEs, Specs, Threat Models, Release Notes, SLAs) auf eine belastbare Zielgruppenliste verweisen können, statt sie jedes Mal neu zu erfinden.
+
+## Ziele
+<!-- Was diese Spec erreichen will. Stichpunkte, ergebnisorientiert. -->
+- Ein konsistentes Verfahren zum Aufzählen der Zielgruppen eines abgesteckten Kontexts bereitstellen
+- Sicherstellen, dass jede identifizierte Zielgruppe über ihre Beziehung zum Kontext charakterisiert wird (konsumieren, betreiben, erweitern, regeln, …)
+- Ein Artefakt erzeugen, auf das andere Specs (`readme-structure`, `pull-request-workflow`, künftige Threat-Modeling-Specs, …) verweisen können
+- Zielgruppen-Identifikation wiederholbar und reviewbar machen — nicht das Bauchgefühl einzelner Autoren
+- Unbekannte oder angenommene Zielgruppen explizit sichtbar machen, damit sie validiert oder verworfen werden können
+
+## Nicht-Ziele
+<!-- Was explizit außerhalb des Scopes liegt. Verhindert Scope Creep. -->
+- Definition von Marketing-Personas oder demografischer Segmentierung
+- Vorgaben, wie mit identifizierten Zielgruppen kommuniziert wird
+- Erzeugen einer dauerhaften, organisationsweiten Master-Zielgruppenliste (diese Spec gilt pro Kontext, nicht pro Organisation)
+- Threat Modeling — Zielgruppen fließen dort ein, sind aber nicht mit Angreifern gleichzusetzen
+- Vorschreiben eines einzigen Artefakt-Formats für jeden Kontext. Der kanonische Default für einen eigenständigen bounded context ist `AUDIENCES.md` an dessen Wurzel (siehe Anforderungen §Artefakt-Ort), aber kleine oder Sub-Modul-Kontexte **DÜRFEN** die Liste in einen README-Abschnitt oder einen ADR einbetten; diese Spec ratifiziert den Default, verbietet die Alternativen aber nicht
+
+## Anforderungen
+<!-- RFC-2119-Schlüsselwörter verwenden: MUST, SHOULD, MAY. Eine atomare Anforderung pro Bullet. -->
+- **MUSS [MUST]** mit einer schriftlichen Deklaration des abgesteckten Kontexts beginnen: was das Modul oder Projekt *ist*, wo seine Grenzen verlaufen und was explizit außerhalb liegt
+- **MUSS [MUST]** Zielgruppen unter folgenden Beziehungskategorien aufzählen und "keine" mit Begründung angeben, wenn eine Kategorie nicht zutrifft:
+  - **Direkte Konsumenten** — wer die Schnittstelle des Kontexts aufruft (Menschen, andere Services, nachgelagerte Bibliotheken)
+  - **Betreiber** — wer den Kontext in Produktion oder Test ausführt, deployt, überwacht oder hostet
+  - **Beitragende / Maintainer** — wer den Code oder dessen Inhalte ändert
+  - **Steuernde Parteien** — Legal, Compliance, Security, Architektur-Review, Business-Stakeholder mit Freigabe- oder Vorgabebefugnis
+  - **Indirekte Zielgruppen** — Parteien, die vom Kontext betroffen sind, ohne direkt mit ihm zu interagieren (z. B. Endnutzer hinter einem konsumierten Service)
+- **MUSS [MUST]** pro gelisteter Zielgruppe erfassen:
+  - kurzes Label
+  - Beziehungskategorie
+  - Interaktionsfläche (API, CLI, Config, Docs, Dashboard, Incident-Kanal, …)
+  - was die Zielgruppe vom Kontext erwartet oder benötigt
+  - die Dokumentations-`track`, auf die die Zielgruppe abbildet (einer aus `user-docs` oder `developer-docs`, gemäß `spec/project/docs-audience-tracks/` §Audience-zu-Spur-Mapping); der Portfolio-Basis-Default (`user` → `user-docs`; `contributor` / `operator` / `release-manager` → `developer-docs`) ist der Ausgangspunkt und pro Projekt mit dokumentierter Einzeiler-Begründung übersteuerbar
+  - offene Fragen oder Annahmen, wenn Informationen fehlen
+- **MUSS [MUST]** jede Zielgruppe als `confirmed` (mit realer Vertretung oder belastbarer Quelle validiert) oder `assumed` (vom Autor angenommen) kennzeichnen
+- **MUSS [MUST]** die Zielgruppenliste erzeugen, bevor nachgelagerte Artefakte geschrieben werden, die eine Zielgruppe beanspruchen (READMEs, Specs, Threat Models, Release Notes, SLAs, Dokumentations-Spuren gemäß `spec/project/docs-audience-tracks/`, …), damit diese darauf verweisen statt sie neu zu formulieren; das Documentation-Tracks-Artefakt ist einer der nachgelagerten Konsumenten und das Per-Audience-`track`-Feld ist die konsumierende Oberfläche
+- **MUSS [MUST]** diese Spec portfolioweit anwenden: jedes Repository, das ein zielgruppen-beanspruchendes nachgelagertes Artefakt produziert (README, Mission, Roadmap, Docs-Spuren, Release Notes, SLAs), MUSS ein Zielgruppen-Artefakt besitzen. Es gibt kein Opt-in oder Opt-out pro Repository; ein Opt-out ist nur pro Beziehungskategorie möglich („keine" mit Begründung dokumentieren). Das *Format* des Artefakts skaliert mit der Kontextgröße (siehe §Artefakt-Ort), das Verfahren selbst wird jedoch nie übersprungen
+- **SOLLTE [SHOULD]** Zielgruppen nach Kritikalität für den Erfolg des Kontexts ordnen (primär / sekundär / peripher)
+- **SOLLTE [SHOULD]** das Zielgruppen-Artefakt unter `AUDIENCES.md` an der Wurzel des bounded context als kanonischen Default ablegen; für kleine Module oder Sub-Kontexte, in denen eine eigenständige Datei überdimensioniert ist, sind ein README-Abschnitt („## Zielgruppen" oder „## Intended consumers") oder ein ADR akzeptable Alternativen. An welchem Ort auch immer das Artefakt liegt, es lebt **neben** dem Kontext, den es beschreibt — nicht in einem zentralen Register —, damit konsumierende Specs (zum Beispiel `mission`, `roadmap`, `release-notes-audience-analysis`, `release-skill-layer` und Tooling wie `github-issue-templates-apply`) es deterministisch finden können; die Liste ist nicht abschließend, und `spec-drift-audit` ist der kanonische Detektor für neu hinzukommende Konsumenten, die das Artefakt zitieren. Es gibt keine minimale Größe, unterhalb der das Verfahren übersprungen wird; für Kontexte, die zu klein für ein eigenes Artefakt sind, wird die Zielgruppenliste in das Artefakt des übergeordneten Kontexts oder in einen README-Abschnitt eingefaltet. Das Format skaliert mit der Größe, das Verfahren nicht
+- **SOLLTE [SHOULD]** die Zielgruppenliste erneut prüfen, sobald sich der Scope des Kontexts wesentlich ändert — neue öffentliche API, neues Deployment-Target, neue regulierte Datenklasse, neuer Stakeholder
+- **SOLLTE [SHOULD]** das Zielgruppen-Artefakt über die Git-Historie des Repositories versionieren; es gibt kein separates Versionsfeld und keinen Per-Release-Snapshot. Die Revisions-Taktung ist ereignisgesteuert gemäß dem §Revisit-Trigger-Bullet oben, und `spec-drift-audit` erkennt, wenn das Artefakt von der tatsächlichen Interaktionsfläche abgedriftet ist
+- **KANN [MAY]** jeden Zielgruppen-Eintrag auf die für ihn erzeugten Specs, Docs oder SLAs verlinken, damit Abdeckung sichtbar wird
+- **KANN [MAY]** Zielgruppen zusätzlich nach Geografie, Organisationseinheit oder Mandantenzuordnung unterteilen, wenn solche Unterschiede das erwartete Liefergut verändern
+
+## Abnahmekriterien
+<!-- Testbare, abhakbare Bedingungen. Reviewer müssen pro Punkt "erfüllt / nicht erfüllt" markieren können. -->
+- [ ] Ein durchgearbeitetes Beispiel existiert, das das Verfahren auf ein konkretes Artefakt dieses Repositories anwendet (z. B. das `nolte-shared`-Plugin oder einen seiner Skills)
+- [ ] Die `readme-structure`-Spec verweist auf diese Spec an der Stelle, an der sie von "intended consumers" spricht
+- [ ] Eine nach dieser Spec erzeugte Zielgruppenliste enthält mindestens eine Zielgruppe pro zutreffender Beziehungskategorie oder dokumentiert "keine" mit Begründung für jede ausgelassene Kategorie
+- [ ] Jeder Zielgruppen-Eintrag unterscheidet `confirmed` von `assumed`
+- [ ] Jeder Zielgruppen-Eintrag trägt ein `track`-Feld, dessen Wert `user-docs` oder `developer-docs` ist (oder ein Erweiterungs-Wert, den eine projekt-typ-spezifische Spec deklariert); der Portfolio-Basis-Default wird angewendet, sofern keine Einzeiler-Override-Begründung inline festgehalten ist
+- [ ] Der abgesteckte Kontext ist schriftlich deklariert, bevor eine Zielgruppe gelistet wird
+- [ ] Der `spec-drift-audit`-Skill kann ein Modul flaggen, dessen dokumentierte Zielgruppen nicht mehr mit der tatsächlichen Interaktionsfläche übereinstimmen
+- [ ] Jeder eigenständige bounded context, der ein Zielgruppen-Artefakt produziert hat, liefert es als `AUDIENCES.md` an der Kontext-Wurzel aus ODER der gewählte Alternativ-Ort (ein README-Abschnitt „## Zielgruppen" / „## Intended consumers" oder ein ADR) ist durch die geringe Kontextgröße oder vorhandene Repo-Präzedenz gerechtfertigt. Verifizierbar durch `find . -name AUDIENCES.md -not -path './node_modules/*' -not -path './.venv/*'` plus einen grep der README-Dateien nach den Abschnitts-Überschriften
+
+## Offene Fragen
+<!-- Ungelöste Entscheidungen, bekannte Unbekannte, Punkte, die eine Stakeholder-Antwort brauchen. -->
+- Wie verhält sich diese Spec zu künftigen Threat-Modeling-, Privacy-Impact- oder SLA-Specs, die dieselbe Zielgruppenliste konsumieren werden? Freischalten, sobald die erste Spec auf der Security-/Privacy-/SLA-Achse, die das Zielgruppen-Artefakt konsumiert, unter `spec/project/` entworfen wird (zum Beispiel `spec/project/threat-modeling/`, `spec/project/privacy-impact/` oder `spec/project/sla/`, deren Anforderungen das Zielgruppen-Artefakt zitieren). Messbar: `grep -rl 'audience' spec/project/{threat-modeling,privacy-impact,sla}/` liefert einen Treffer. Dann den konkreten bidirektionalen Querverweis verdrahten; die `spec-drift-audit`-Klausel „neu hinzukommende Konsumenten, die das Artefakt zitieren" (siehe die §Artefakt-Ort-Anforderung) macht die Abhängigkeit sichtbar. Kein externer Upstream-Link betroffen — dies ist ein internes Portfolio-Authoring-Ereignis, keine Abhängigkeit von der Claude-Code-Plattform.

--- a/spec/project/audience-identification/en.md
+++ b/spec/project/audience-identification/en.md
@@ -1,0 +1,65 @@
+# Audience Identification
+
+Status: draft
+
+## Context
+<!-- Why does this spec exist? What problem, user need, or constraint drives it? -->
+
+Software modules and projects are consumed, operated, constrained, or observed by multiple audience groups—users, operators, downstream integrators, maintainers, security, compliance, business stakeholders, indirect end users, and more. Without a disciplined way to enumerate which audiences apply to a *bounded context* (a specific module, service, library, or project), decisions about documentation depth, API surface, release cadence, SLAs, and security posture are made against the author's private assumptions rather than against the actual audience set. This spec defines a repeatable method to identify and characterize the audiences of any scoped context so that downstream artifacts (READMEs, specs, threat models, release notes, SLAs) can reference an authoritative audience list instead of reinventing one each time.
+
+## Goals
+<!-- What this spec aims to achieve. Bullet points, outcome-oriented. -->
+- Provide a consistent procedure for enumerating the audiences of a defined context
+- Ensure every identified audience is characterized by its relationship to the context (consume, operate, extend, govern, …)
+- Produce an artifact that other specs (`readme-structure`, `pull-request-workflow`, future threat-modeling specs, …) can point to
+- Make audience identification repeatable and reviewable rather than the output of a single author's gut feel
+- Surface unknown or assumed audiences explicitly so they can be validated or retired
+
+## Non-Goals
+<!-- Explicitly out of scope. Prevents creep. -->
+- Defining marketing personas or demographic segmentation
+- Prescribing how to engage or communicate with audiences once identified
+- Producing a permanent, organization-wide master audience list (this spec is scoped per context, not per org)
+- Threat modeling—audiences feed into it but aren't equivalent to threat actors
+- Mandating a single artifact format for every context. The canonical default for a stand-alone bounded context is `AUDIENCES.md` at the root of that context (see Requirements §Artifact location), but small or sub-module contexts MAY embed the list in a README section or an ADR; this spec ratifies the default rather than forbidding the alternatives
+
+## Requirements
+<!-- Use RFC 2119 keywords: MUST, SHOULD, MAY. One atomic requirement per bullet. -->
+- **MUST** begin with a written declaration of the bounded context: what the module or project *is*, where its boundaries run, and what's explicitly outside
+- **MUST** enumerate audiences under the following relationship categories, and state "none" with a reason when a category doesn't apply:
+  - **Direct consumers**: who invokes the context's interface (humans, other services, downstream libraries)
+  - **Operators**: who runs, deploys, monitors, or hosts the context in production or test
+  - **Contributors / maintainers**: who modifies the code or authors its content
+  - **Governing parties**: legal, compliance, security, architecture review, business stakeholders with approval or constraint authority
+  - **Indirect audiences**: parties affected by the context without interacting with it directly (for example end users behind a consumed service)
+- **MUST** record for every listed audience:
+  - a short label
+  - the relationship category
+  - the interaction surface (API, CLI, config, docs, dashboard, incident channel, …)
+  - what the audience expects or needs from the context
+  - the documentation `track` the audience maps to (one of `user-docs` or `developer-docs`, per `spec/project/docs-audience-tracks/` §Audience-to-track mapping); the portfolio-baseline default (`user` → `user-docs`; `contributor` / `operator` / `release-manager` → `developer-docs`) is the starting point and is overridable per project with a recorded one-line rationale
+  - any open question or assumption where information is missing
+- **MUST** tag every audience as `confirmed` (validated with a real representative or an authoritative source) or `assumed` (inferred by the author)
+- **MUST** produce the audience list before downstream artifacts that claim an audience are written (READMEs, specs, threat models, release notes, SLAs, documentation tracks per `spec/project/docs-audience-tracks/`, …), so those artifacts can reference it rather than restate it; the documentation-tracks artefact is one of the downstream consumers and the per-audience `track` field is the consuming surface
+- **MUST** apply this spec portfolio-wide: any repository that produces an audience-claiming downstream artifact (README, mission, roadmap, docs tracks, release notes, SLAs) MUST have an audience artifact. There is no per-repository opt-in or opt-out; opt-out is per relationship category only (record "none" with a reason). The artifact's *format* scales with context size (see §Artifact location), but the method itself is never skipped
+- **SHOULD** rank audiences by criticality to the success of the context (primary / secondary / peripheral)
+- **SHOULD** store the audience artifact at `AUDIENCES.md` at the root of the bounded context as the canonical default; for small modules or sub-contexts where a stand-alone file is overkill, a README section ("## Audiences" or "## Intended consumers") or an ADR is an acceptable alternative. Whichever location is chosen, the artifact lives **alongside** the context it describes—not in a central registry—so consuming specs (for example `mission`, `roadmap`, `release-notes-audience-analysis`, `release-skill-layer`, and tooling like `github-issue-templates-apply`) can locate it deterministically; the list isn't exhaustive, and `spec-drift-audit` is the canonical detector for newly-added consumers that cite the artefact. There is no minimum size below which the method is skipped; for contexts too small to warrant their own artifact, fold the audience list into the parent context's artifact or a README section. The format scales with size, the method doesn't
+- **SHOULD** revisit the audience list whenever the context's scope materially changes—new public API, new deployment target, new regulated data class, new stakeholder
+- **SHOULD** version the audience artifact through the repository's git history; there is no separate version field or per-release snapshot. The revision cadence is event-driven per the §revisit-triggers bullet above, and `spec-drift-audit` detects when the artifact has drifted from the actual interaction surface
+- **MAY** link each audience entry to the specs, docs, or SLAs produced for it, so coverage is visible
+- **MAY** subdivide audiences further by geography, organizational unit, or tenancy when such distinctions change the expected deliverable
+
+## Acceptance Criteria
+<!-- Testable, checkable conditions. A reviewer should be able to mark each as done/not done. -->
+- [ ] A worked example exists applying the method to one concrete artifact in this repository (for example the `nolte-shared` plugin or one of its skills)
+- [ ] The `readme-structure` spec references this spec where it speaks of "intended consumers"
+- [ ] An audience list produced under this spec contains at least one audience per applicable relationship category, or records "none" with a reason for any category it omits
+- [ ] Every audience entry distinguishes `confirmed` from `assumed`
+- [ ] Every audience entry carries a `track` field whose value is `user-docs` or `developer-docs` (or an extension value declared by a project-type-specific spec); the portfolio-baseline default is applied unless a one-line override rationale is recorded inline
+- [ ] The bounded context is declared in writing before any audience is listed
+- [ ] The `spec-drift-audit` skill can flag a module whose documented audiences no longer match its actual interaction surface
+- [ ] Every stand-alone bounded context that has produced an audience artifact ships it as `AUDIENCES.md` at the context root, OR the chosen alternative location (a README section "## Audiences" / "## Intended consumers" or an ADR) is justified by the context's small size or by pre-existing repo precedent. Verifiable by `find . -name AUDIENCES.md -not -path './node_modules/*' -not -path './.venv/*'` plus a grep of README files for the section headings
+
+## Open Questions
+<!-- Unresolved decisions, known unknowns, things that need a stakeholder answer. -->
+- How does this spec interact with future threat-modeling, privacy-impact, or SLA specs that will also consume the same audience list? Unblock when the first spec on the security/privacy/SLA axis that consumes the audience artifact is drafted under `spec/project/` (for example `spec/project/threat-modeling/`, `spec/project/privacy-impact/`, or `spec/project/sla/` whose Requirements cite the audience artifact). Measurable: `grep -rl 'audience' spec/project/{threat-modeling,privacy-impact,sla}/` returns a hit. Then wire the concrete bidirectional cross-reference; the `spec-drift-audit` "newly-added consumers that cite the artefact" clause (see the §Artifact-location requirement) surfaces the dependency. No external upstream link applies—this is an internal portfolio authoring event, not a Claude Code platform dependency.

--- a/spec/project/feature/de.md
+++ b/spec/project/feature/de.md
@@ -1,0 +1,125 @@
+# Projekt-Feature
+
+Status: draft
+
+## Kontext
+
+Leser: Repo-Maintainer von Hobby-Projekten im nolte-Portfolio, die die Skills `feature-decompose`, `sprint-execute` und `sprint-review` aufrufen (die letzten beiden lesen Features, besitzen sie aber nicht), den Agent `feature-consistency-reviewer`, sowie die Implementierer dieser Skills und des Agents, die gegen das hier definierte Schema bauen.
+
+Die Geschwister-Spec `roadmap` definiert, welche Arbeit ansteht und warum; die Geschwister-Spec `sprint` definiert, wie Arbeit gruppiert und ausgeliefert wird. Dazwischen sitzt die Ausführungseinheit: ein Feature. Ein Feature im nolte-Portfolio ist eine über Markdown verwaltete, sprint-gebundene, roadmap-verknüpfte Stück nutzersichtbarer Veränderung. Es ist das kleinste Objekt, das Akzeptanzkriterien trägt, das kleinste Objekt, auf dem konsumierende Claude-Skills (`feature-decompose`, `sprint-execute`, der Agent `feature-consistency-reviewer`) operieren, und das kleinste Objekt, dessen Zustandsmaschine von Sprint-Ebene aus beobachtbar ist. Diese Spec legt Datei-Form, Schema, Lifecycle und — einzigartig auf dieser Ebene — eine **verpflichtende Konsistenzprüfung** gegen bestehende Features und bestehenden Quellcode fest, bevor ein neues Feature als bereit gilt: Hobby-Projekte sammeln schnell latente Überlappungen an, und eine Authoring-Schicht, die diese nicht sichtbar macht, lässt sie ungebremst wachsen.
+
+## Ziele
+
+- Die Datei-Form eines Features als eine einzige Markdown-Datei unter `project/features/<slug>.md` festlegen, eine Datei pro Feature, mit stabilem Frontmatter-Schema und verpflichtenden Body-Sections, damit konsumierende Skills Features deterministisch parsen, ändern und validieren können.
+- Den Feature-Lifecycle festlegen (`draft → ready → in_progress → done`, plus `cancelled`) und die Mindest-Gates pro Übergang, damit Authoring, Ausführung und Abschluss in nicht überlappenden Skill-Zuständigkeiten leben.
+- Die **Konsistenzprüfung** erzwingen: bevor ein Feature `draft` verlässt, **MUSS [MUST]** es gegen den bestehenden Feature-Bestand und gegen die bestehende Quellcode-Oberfläche auf Überlappung, Duplikation und Drift geprüft werden; die Prüfung wird an den Agent `feature-consistency-reviewer` delegiert, und die Befunde **MÜSSEN [MUST]** am Feature selbst dokumentiert werden.
+- Jedes Feature an genau ein Roadmap-Item (`R-<n>`) und einen Sprint (`<NNNN>`) zurückbinden, damit Nachverfolgbarkeit lückenlos von Roadmap → Sprint → Feature → Akzeptanzkriterium → ausrollbarem Artefakt fließt.
+- Einen klaren Akzeptanzkriterien-Vertrag festlegen: Kriterien sind testbar, einzeln abhakbar, und mindestens ein Kriterium pro Sprint ist nötig, um das `value_statement` des Sprints zu prüfen (die Anforderung wird sprint-seitig erzwungen, aber die **Form** eines Akzeptanzkriteriums plus der **Frontmatter-Marker**, der das mehrwert-prüfende Kriterium kennzeichnet, werden hier definiert).
+- Portfolio-weit wiederverwendbar bleiben: jeder im Portfolio unterstützte Projekttyp (Claude-Plugin, Python-Anwendung, Python-Bibliothek, Node / TypeScript, CLI-Tool, dokumentations-only) kann das Schema **unverändert** übernehmen: das Frontmatter-Schema und die Body-Sections sind über alle Projekttypen identisch, typ-spezifische Hinweise leben nur in Body-Inhalten (Description-Sprache, Test-Hook-Konventionen) und **DÜRFEN NICHT [MUST NOT]** das Schema oder die Section-Liste pro Projekttyp verzweigen.
+
+## Nicht-Ziele
+
+- Roadmap-, Sprint- oder Release-Artefakt-Innenleben festzulegen. Jedes davon gehört seiner eigenen Geschwister-Spec; diese Spec erklärt nur die Feature-seitige Oberfläche und die Querverweise, die sie trägt.
+- Test-Frameworks zu ersetzen. Akzeptanzkriterien verweisen auf Tests, manuelle Demo-Schritte oder Skill-Aufrufe; die Feature-Spec führt sie nicht aus, sondern listet und verfolgt sie nur.
+- Eine spezifische Implementierungssprache oder ein Framework zu erzwingen. Die Spec regelt Authoring- und Tracking-Form, nicht das Wie der Umsetzung.
+- `audience-identification`- oder audience-doc-author-Tooling zu ersetzen. Feature-Dokumentation für Endnutzer gehört zur Doc-Author-Oberfläche; das Feature-Markdown ist ein internes Planungs-Artefakt.
+- `continuous-improvement`, `spec-drift-audit` oder `spec-readiness` zu ersetzen. Diese regeln Prozess und Spec-Hygiene; diese Spec regelt Feature-Artefakt-Hygiene.
+- Die Logik des `feature-consistency-reviewer`-Agents zu ersetzen. Die Untersuchungs-Oberfläche des Agents (welche Pfade zu lesen sind, wie Überlappung bewertet wird) ist seine eigene Sache; diese Spec verlangt nur, **dass** die Prüfung passiert und **was** dokumentiert wird.
+
+## Anforderungen
+
+### Verzeichnislayout und Datei-Form
+
+- **MUSS [MUST]** jedes Feature unter `project/features/<slug>.md` ablegen, wobei `<slug>` eine ASCII-kebab-case-Zusammenfassung des Feature-Titels ist, stabil über die gesamte Lebensdauer des Features.
+- **MUSS [MUST]** genau eine Markdown-Datei pro Feature führen; Feature-Inhalt wird nie über mehrere Dateien gesplittet.
+- **DARF NICHT [MUST NOT]** den Slug eines Features umbenennen, nachdem es `draft` verlassen hat; Umbenennungen brechen Sprint- und Roadmap-Rück-Referenzen still.
+- **SOLLTE [SHOULD]** `<slug>` so kurz halten, dass er in Verzeichnislisten lesbar bleibt (≤ 6 Wörter kebab-cased ist die Zielform).
+
+### Frontmatter-Schema
+
+- **MUSS [MUST]** die Datei mit einem YAML-Frontmatter-Fence öffnen, der folgende Felder in dieser Reihenfolge trägt:
+  - `id` (String, verpflichtend) — Muster `F-<n>`, projektweit monoton vergeben, niemals wiederverwendet;
+  - `title` (String, verpflichtend) — einzeilige Zusammenfassung in der Hauptsprache des Projekts;
+  - `status` (Enum, verpflichtend) — einer von `draft`, `ready`, `in_progress`, `done`, `cancelled`;
+  - `roadmap_item` (String, verpflichtend) — die `R-<n>`-ID, die dieses Feature zerlegt; **MUSS [MUST]** zu einem Eintrag in `project/roadmap.md` matchen;
+  - `sprint` (Integer oder null, verpflichtend) — die Sprint-Nummer, für die das Feature eingeplant ist; null während `draft` und während `ready` so lange das Feature von keinem Sprint übernommen wurde. Das Feld wechselt genau dann von null auf nicht-null, wenn das Feature laut `spec/project/sprint/` in die `features`-Liste eines Sprints aufgenommen wird; die kanonische Schreib-Autorität ist `sprint-plan` (wenn vor der Aktivierung geplant wird) oder `sprint-execute` (wenn das Feature mitten in einem aktiven Sprint aufgenommen wird), und jede der beiden **MUSS [MUST]** `feature.sprint = N` in derselben Operation schreiben, die `feature.id` zu `sprints/N.features` hinzufügt. Das Feld **DARF NICHT [MUST NOT]** von Hand oder durch einen anderen Skill gesetzt werden; die bidirektionale Invariante (Feature-Seite ↔ Sprint-Seite) ist die kanonische Prüfung;
+  - `created` (ISO-Datum, verpflichtend) — Datum, an dem die Feature-Datei erstmals geschrieben wurde; nach Erstellung nie editiert;
+  - `ended` (ISO-Datum oder null, verpflichtend) — Datum, an dem das Feature entweder `done` oder `cancelled` erreicht hat (beide terminalen Zustände teilen dieses Feld, daher der neutrale Name); null bis das Feature terminal ist;
+  - `verifies_sprint_value` (String oder null, verpflichtend) — der Akzeptanzkriterium-Bezeichner (`acceptance-<n>`) auf diesem Feature, der beim Abhaken das `value_statement` des Sprints direkt prüft; nicht-null auf höchstens einem Feature pro Sprint, sonst null. Die Geschwister-Spec `sprint` verlangt, dass in jedem schließenden Sprint **mindestens ein** Feature hier einen nicht-null-Wert trägt; zusammen mit der hier feature-seitig durchgesetzten At-most-one-Schranke (siehe §Akzeptanzkriterien-Vertrag und das AC weiter unten) ergibt sich netto die Bedingung "genau eines". Schreib-Autorität ist `feature-decompose` (wenn das verifizierende Kriterium bei der Decomposition identifiziert wird) oder `sprint-plan` (wenn das verifizierende Kriterium während der Planung neu zugewiesen wird); das Feld **MUSS [MUST]** auf genau einem Feature pro Sprint nicht-null sein, **bevor** dieser Sprint nach `review` übergeht;
+  - `consistency_check` (Objekt, verpflichtend) — siehe §Konsistenzprüfung-Schema unten.
+- **DARF NICHT [MUST NOT]** Aufwandsschätzungen, Punkte oder Zuweisungsfelder jenseits der oben deklarierten enthalten; Lints flaggen unbekannte Schlüsselwörter.
+
+### Body-Sections
+
+- **MUSS [MUST]** folgende Level-2-Sections in dieser Reihenfolge tragen, auch wenn leer (Skills hängen an stabilen Section-Überschriften):
+  - `## Description` — ein bis drei Absätze, die die nutzersichtbare Veränderung beschreiben; in der Hauptsprache des Projekts geschrieben; aus Endnutzer-Sicht formuliert, wann immer möglich.
+  - `## Acceptance criteria` — Checkliste testbarer, einzeln abhakbarer Bedingungen; siehe §Akzeptanzkriterien-Vertrag für die Form pro Eintrag.
+  - `## Test hooks` — explizite Liste, welche Tests, Skills oder manuellen Demo-Schritte welche Akzeptanzkriterien validieren. Jeder Eintrag **MUSS [MUST]** drei Komponenten tragen: (a) den `acceptance-<n>`-Bezeichner, an den er pinnt; (b) den Verifikations-Mechanismus (Test-Pfad, Skill-Name, CLI-Befehl oder manuelles Vorgehen); (c) ein Status-Token aus dem geschlossenen Vokabular `pending` (noch nicht ausgeführt), `passing` (ausgeführt und erfolgreich), `skipped` (für diesen Lauf bewusst nicht ausgeführt, mit Begründung) oder `failing` (ausgeführt und nicht erfolgreich). Format: `- **acceptance-<n>** — <Mechanismus> — <Status>`. Ein Hook gilt für das Lifecycle-Gate (siehe §Lifecycle und Gates) nur dann als "aufgelöst", wenn sein Status `passing` oder `skipped` ist.
+  - `## Consistency notes` — wird durch die Konsistenzprüfung befüllt (siehe §Konsistenzprüfung); fasst die Befunde des Agents und die für jeden Befund gewählte Auflösung zusammen.
+  - `## Risks` — bekannte Unbekannte, Blocker oder Mitigationen; **KANN [MAY]** für risikoarme Features leer sein.
+- **KANN [MAY]** zusätzliche Level-2-Sections tragen (`## Open questions`, `## References`), wenn das Feature sie wirklich braucht; **DARF NICHT [MUST NOT]** die Reihenfolge der verpflichtenden Sections wegen optionaler ändern.
+
+### Akzeptanzkriterien-Vertrag
+
+- **MUSS [MUST]** jedes Akzeptanzkriterium als Markdown-Checkbox-Bullet (`- [ ] …`) formulieren, ein Kriterium pro Bullet, atomar (eine einzelne Prüfung), testbar (ein Reviewer kann eindeutig Erledigt/Nicht-Erledigt markieren).
+- **MUSS [MUST]** einen stabilen, pro-Feature eindeutigen Kriterium-Bezeichner im Bullet-Text vergeben, im Muster `acceptance-<n>` (zum Beispiel `- [ ] **acceptance-1** Sensorwert erscheint innerhalb von 5 s nach Geräte-Discovery`); dieser Bezeichner wird vom Frontmatter-Feld `verifies_sprint_value` referenziert und ist das, woran `## Test hooks`-Einträge gepinnt werden.
+- **DARF NICHT [MUST NOT]** prozess-interne Kriterien tragen ("PR genehmigt", "in develop gemerged"); Akzeptanzkriterien sind nutzersichtbares Verhalten, keine Workflow-Gates.
+- **SOLLTE [SHOULD]** drei bis sieben Kriterien pro Feature anpeilen; eines ist verdächtig (unterspezifiziert), mehr als zehn legt nahe, dass das Feature gesplittet werden sollte.
+- **DARF NICHT [MUST NOT]** sich auf Prosa-Marker im Bullet-Text verlassen, um das mehrwert-prüfende Kriterium zu identifizieren; das einzige autoritative Signal ist das Frontmatter-Feld `verifies_sprint_value`. Autoren **KÖNNEN [MAY]** die Verifizierungs-Rolle in menschenlesbarer Prosa zur Lesefreundlichkeit erwähnen, aber konsumierende Skills **MÜSSEN [MUST]** das Frontmatter parsen, nicht den Bullet-Text.
+
+### Konsistenzprüfung
+
+- **MUSS [MUST]** eine Konsistenzprüfung durchführen, bevor ein Feature von `draft` nach `ready` übergeht. Kanonischer Ausführer ist der Agent `feature-consistency-reviewer` (laut `spec/claude/agent-management/`); bis dieser Agent existiert, **KANN [MAY]** ein operator-getriebener manueller Durchgang dieselbe Anforderung erfüllen, **vorausgesetzt** er folgt derselben Investigations-Oberfläche und Aufzeichnungs-Form, der manuelle Durchgang wird mit `agent_version: manual-<YYYY-MM-DD>` in `consistency_check` festgehalten und die `## Consistency notes`-Section nennt den ausführenden Operator. Sobald der Agent existiert, **MUSS [MUST]** der manuelle Fallback entfernt werden, und jedes Feature, das sich danach noch darauf stützt, ist ein workflow-health-Finding. Die Prüfung (egal ob Agent oder manuell) untersucht:
+  - den bestehenden Feature-Bestand unter `project/features/` auf überlappende oder widersprechende Features;
+  - die bestehende Quellcode-Oberfläche (die primären Source-Roots des Projekts, identifiziert über Repo-Konventionen) auf bereits implementiertes Verhalten, das das neue Feature neu implementieren würde; die Quellcode-Oberfläche folgt demjenigen Primary-Source-Layout, das `spec/project/project-structure/` für das konsumierende Repo anerkennt, sodass bei einem Claude-Code-Plugin-Repo die Oberfläche ausdrücklich `skills/<name>/SKILL.md`, `agents/<name>.md` und `.claude-plugin/plugin.json` **einschließt** (das ausführbare Verhalten des Plugins lebt in diesen Dateien, auch wenn sie Markdown sind), genauso wie sie bei Repos mit anderen Layouts `src/`, `src/<component>/`, `custom_components/<name>/`, `playbooks/` und `roles/` einschließt;
+  - den Spec-Bestand unter `spec/` auf frühere Entscheidungen, die dieses Feature einschränken.
+- **MUSS [MUST]** die Befunde des Agents am Feature in der Body-Section `## Consistency notes` und als strukturiertes Frontmatter-Objekt `consistency_check` mit folgenden Feldern dokumentieren:
+  - `performed_at` (ISO-Datum, verpflichtend) — wann die Prüfung lief;
+  - `agent_version` (String, optional) — Agent-Bezeichner, damit Re-Runs diffbar sind;
+  - `findings` (Liste, verpflichtend) — jeder Befund mit `kind` (`overlap`, `duplication`, `drift`, `prior-art`, `clean`), `target` (Dateipfad oder Feature-ID, auf die er sich bezieht) und `resolution` (`merge-into <id>`, `supersede <id>`, `split-out <ids>`, `proceed`, `revisit-after <event>`).
+- **MUSS [MUST]** jeden Befund mit `kind: overlap` oder `kind: duplication` als Blocker für den Übergang `draft → ready` behandeln, sofern seine `resolution` nicht `proceed` mit einer expliziten ein-absätzigen Begründung in `## Consistency notes` ist.
+- **MUSS [MUST]** die Konsistenzprüfung erneut laufen lassen, sobald während des Status `ready` oder `in_progress` eines der folgenden Ereignisse eintritt: die `## Description`-Section ändert sich über Tippfehler-Niveau hinaus, ein Akzeptanzkriterium wird hinzugefügt oder seine Kern-Formulierung (ohne den Checkbox-Zustand) geändert, das Frontmatter-Feld `roadmap_item` oder `sprint` wird geändert, oder ein Feature mit überlappendem Scope wird anderswo unter `project/features/` hinzugefügt oder entfernt. Der Re-Run **MUSS [MUST]** historische Befunde bewahren (einen neuen `findings`-Block mit `performed_at`-Datum anhängen, nicht überschreiben). Kosmetische Änderungen (Tippfehler-Korrekturen, Formatierung, Link-Ziel-Normalisierung, das Umschalten der Bullet-Checkbox eines bestehenden Akzeptanzkriteriums) **DÜRFEN NICHT [MUST NOT]** einen Re-Run auslösen.
+- **MUSS [MUST]** die Befunde inline am Feature dokumentieren (im `consistency_check`-Frontmatter und in `## Consistency notes`), niemals als separates `.audits/feature-consistency/`-Artefakt. Anders als die transienten `skill-review`/`agent-review`-Pläne unter `.audits/` (die `spec/claude/review-plan/` als nach Abschluss löschbare Arbeitsdokumente definiert) sind Konsistenz-Befunde dauerhafte, nur-anhängende Feature-Metadaten, die den Lifecycle `draft → ready` gaten und daher am Feature selbst leben.
+- **MUSS [MUST]** das `consistency_check`-Objekt unabhängig von der Länge der `findings`-Historie inline am Feature halten; eine Auslagerung in eine separate Datei ist entschieden-dagegen, weil die Befunde den Lifecycle gaten und am Feature selbst diffbar bleiben müssen.
+
+### Lifecycle und Gates
+
+- **MUSS [MUST]** `status` nur entlang dieser Pfade übergehen lassen: `draft → ready`, `ready → in_progress`, `in_progress → done` und `cancelled` aus jedem von `draft`, `ready`, `in_progress` erreichbar. Direktes `draft → in_progress`, `draft → done` und `ready → done` ist verboten, weil es die Konsistenzprüfung oder das Ausführungs-Gate überspringt.
+- **MUSS [MUST]** vor `draft → ready` verlangen: ein nicht-leeres `## Description`, mindestens ein Akzeptanzkriterium-Bullet, ein befülltes `consistency_check`-Frontmatter und eine befüllte `## Consistency notes`-Section.
+- **MUSS [MUST]** vor `ready → in_progress` verlangen: einen nicht-null `sprint`-Wert, der entweder dem aktuell `active` Sprint oder dem niedrigst-nummerierten `planned`-Sprint laut Geschwister-Spec `sprint` entspricht, und das Feature ist im `features`-Feld dieses Sprints gelistet. Ist der gematchte Sprint `planned`, befördert `sprint-execute` ihn als Seiteneffekt dieses Übergangs automatisch nach `active` (laut `sprint` §Lifecycle); ist bereits ein anderer Sprint `active`, wird der Übergang abgelehnt.
+- **MUSS [MUST]** vor `in_progress → done` verlangen: jedes Akzeptanzkriterium abgehakt, jeder Test-Hook aufgelöst (Status `passing` oder `skipped` laut §Body-Sections) und der Sprint des Features entweder `active` oder `review`.
+- **KANN [MAY]** zu jedem Zeitpunkt vor `done` nach `cancelled` übergehen; der Übergang **MUSS [MUST]** eine ein-absätzige Begründung tragen, in `## Risks`, wenn das Feature vor dem Konsistenzprüfungs-Lauf abgebrochen wurde (Status `draft` zum Abbruchszeitpunkt), und in `## Consistency notes`, wenn das Feature im Status `ready` oder `in_progress` abgebrochen wurde, weil die Konsistenzprüfung oder ein späterer Befund zeigte, dass das Feature nicht gebaut werden sollte.
+
+### Roadmap-, Sprint- und Source-Verknüpfung
+
+- **MUSS [MUST]** sicherstellen, dass `roadmap_item` auf ein in `project/roadmap.md` deklariertes `R-<n>` auflöst; ein Feature ohne Roadmap-Verknüpfung ist auch dann ungültig, wenn die ursprüngliche Motivation "interne Härtung" ist — ein Roadmap-Item für die Härtungs-Absicht zuerst deklarieren.
+- **MUSS [MUST]** sicherstellen, dass — wenn `sprint` nicht null ist — die `features`-Frontmatter-Liste der referenzierten Sprint-Datei die `id` dieses Features enthält; die Rück-Referenz ist bidirektional und wird bei jeder Sprint- und Feature-Änderung validiert.
+- **MUSS [MUST]** zulassen, dass `## Test hooks` auf Source-Pfade, Test-Pfade oder Skill-Namen zeigt; die Spec schränkt nicht ein, welchen Mechanismus ein Hook wählt, nur dass der Mechanismus explizit benannt ist, damit die Konsistenzprüfung Vorarbeit lokalisieren kann.
+- **KANN [MAY]** Verweise auf externe Issues (GitHub-Issues, Project-Boards) in `## Description` oder `## References` tragen; diese Verweise sind Dokumentation, niemals autoritativ.
+
+### Hobby-Skala-Varianz
+
+- **DARF NICHT [MUST NOT]** Aufwandsschätzungen, Fälligkeitsdaten oder Velocity-Tracking auf Features verlangen; wie Roadmap-Items und Sprints sind Features im Tempo des Autors.
+- **SOLLTE [SHOULD]** lange Strecken zwischen Konsistenzprüfung und Ausführung tolerieren; vergehen mehr als zwei Sprints ohne Ausführung, **SOLLTE [SHOULD]** die Konsistenzprüfung vor `ready → in_progress` erneut laufen.
+- **KANN [MAY]** ein Feature `cancelled` markieren, wenn die Konsistenzprüfung zeigt, dass ein bestehendes Feature es bereits abdeckt; Abbruch mit `resolution: merge-into <id>` ist ein erstklassiges Ergebnis, kein Fehlerzustand.
+- **MUSS [MUST]** auf dokumentations-only-Features (eine How-to-Seite, ein Runbook) das identische Schema und denselben Lifecycle anwenden; die No-per-Type-Branching-Regel (Ziel 6) lässt keine Doc-Feature-Ausnahme zu, und ein Doc-Feature bleibt ein internes Planungs-Artefakt, das denselben Akzeptanzkriterien-, Test-Hook- und Konsistenz-Vertrag trägt wie jedes andere Feature.
+
+## Akzeptanzkriterien
+
+- [ ] Jedes Feature existiert als genau eine Datei unter `project/features/<slug>.md` mit stabilem Slug; kein Slug wird umbenannt, nachdem das Feature `draft` verlassen hat.
+- [ ] Das Frontmatter jedes Features trägt die neun Schema-Felder (`id`, `title`, `status`, `roadmap_item`, `sprint`, `created`, `ended`, `verifies_sprint_value`, `consistency_check`) in der festgelegten Reihenfolge; Lints flaggen unbekannte Schlüsselwörter und lehnen `closed` als Frontmatter-Feldname ab (das Feld heißt `ended`).
+- [ ] Der Body jedes Features trägt die fünf verpflichtenden Level-2-Sections (`Description`, `Acceptance criteria`, `Test hooks`, `Consistency notes`, `Risks`) in der festgelegten Reihenfolge; fehlende Sections schlagen die Validierung.
+- [ ] Jedes Akzeptanzkriterium-Bullet nutzt das Muster `**acceptance-<n>**` und ist atomar, testbar und nutzersichtbar (kein Workflow-Gate); kein Bullet trägt einen Inline-Mehrwert-Verifizier-Marker (das einzige autoritative Signal ist das Frontmatter-Feld `verifies_sprint_value`).
+- [ ] Jeder `## Test hooks`-Eintrag pinnt an einen `acceptance-<n>`-Bezeichner, benennt einen Verifikations-Mechanismus und trägt ein Status-Token aus dem geschlossenen Vokabular (`pending`, `passing`, `skipped`, `failing`); Einträge ohne eine der drei Komponenten schlagen die Validierung.
+- [ ] Kein Feature wechselt `draft → ready` ohne ein befülltes `consistency_check`-Frontmatter-Objekt, dessen `findings`-Array nicht leer ist (auch ein sauberer Lauf wird mit `kind: clean` dokumentiert), und eine befüllte `## Consistency notes`-Section.
+- [ ] Kein Feature wechselt `ready → in_progress`, solange ein anderer Sprint als der in seinem `sprint`-Feld referenzierte `active` ist; das Gate wird von `sprint-execute` durchgesetzt und löst die `planned → active`-Beförderung aus, wenn anwendbar.
+- [ ] Kein Feature wechselt `in_progress → done`, solange ein Akzeptanzkriterium-Bullet ungeprüft oder der Status eines Test-Hooks `pending` oder `failing` ist.
+- [ ] Es treten keine direkten Übergänge für `draft → in_progress`, `draft → done` oder `ready → done` auf; Verstöße gegen den Übergangsgraphen werden von den konsumierenden Skills abgelehnt.
+- [ ] Jeder `consistency_check.findings`-Eintrag mit `kind` `overlap` oder `duplication` hat entweder eine nicht-`proceed`-Auflösung oder trägt eine ein-absätzige Begründung in `## Consistency notes`, die die `proceed`-Wahl rechtfertigt.
+- [ ] Höchstens ein Feature pro Sprint trägt einen nicht-null `verifies_sprint_value`; Sprints, die mit null oder mehr als einem solchen Feature schließen, schlagen die sprint-seitige Validierung laut Geschwister-Spec `sprint`.
+- [ ] Jedes abgebrochene Feature trägt eine ein-absätzige Begründung: in `## Risks`, wenn im `draft` abgebrochen, in `## Consistency notes`, wenn im `ready` oder `in_progress` abgebrochen. Fehlende Begründung schlägt die Validierung.
+- [ ] Kein Feature-Schema verzweigt nach Projekttyp; das Schema und die Body-Section-Liste sind über Claude-Plugin, Python-Anwendung, Python-Bibliothek, Node / TypeScript, CLI-Tool und dokumentations-only-Repos identisch.
+
+## Offene Fragen
+
+- Cross-Feature-Abhängigkeiten (`F-7 braucht F-3 zuerst`) tragen heute kein Schema-Feld; die Sprint-Zugehörigkeit plus die `roadmap_item`-Verknüpfung drücken die einzige existierende Sequenzierung aus. Revisitieren, sobald eine echte Feature-Kette auftaucht, die die Sprint-Reihenfolge nicht ausdrücken kann—konkret: zwei Features landen, bei denen die `## Acceptance criteria` oder `## Test hooks` des späteren auf ein Verhalten verweisen, das das frühere einführt, beide sind in DENSELBEN `sprint` eingeplant (sodass die Sprint-Reihenfolge sie nicht sequenzieren kann), UND die Konsistenzprüfung kann die Reihenfolge nicht als `prior-art`/`revisit-after`-Befund erfassen. Das erste solche Auftreten gibt frei, `depends_on` SOWOHL dem Feature-Schema ALS AUCH der Geschwister-Spec `sprint` im Gleichschritt hinzuzufügen (die Sprint-Spec trägt heute kein Abhängigkeits- oder Reihenfolge-Feld, sodass eine nur feature-seitige Ergänzung eine einseitige Invariante wäre).

--- a/spec/project/feature/en.md
+++ b/spec/project/feature/en.md
@@ -1,0 +1,125 @@
+# Project Feature
+
+Status: draft
+
+## Context
+
+Readers: repo maintainers of hobby-scale nolte projects who invoke the `feature-decompose`, `sprint-execute`, and `sprint-review` skills (the latter two read features but don't own them), plus the `feature-consistency-reviewer` agent, plus the implementing authors writing those skills and the agent against this schema.
+
+The sibling `roadmap` spec defines what work is queued and why; the sibling `sprint` spec defines how work is grouped and shipped. Between them sits the unit of execution: a feature. A feature in the nolte portfolio is a markdown-tracked, sprint-bound, roadmap-linked piece of user-visible change. It's the smallest object that carries acceptance criteria, the smallest object that consuming Claude skills (`feature-decompose`, `sprint-execute`, the `feature-consistency-reviewer` agent) operate on, and the smallest object whose state machine is observable from the sprint level. This spec defines the on-disk shape, the schema, the lifecycle, and—uniquely on this layer—a **mandatory consistency check** against existing features and existing source code before a new feature is considered ready: hobby-scale projects accumulate latent overlap quickly, and an authoring layer that doesn't surface that overlap will let it grow unchecked.
+
+## Goals
+
+- Define the on-disk shape of a feature as a single markdown file at `project/features/<slug>.md`, one file per feature, with a stable frontmatter schema and required body sections so consuming skills can parse, mutate, and validate features deterministically.
+- Specify the per-feature lifecycle (`draft → ready → in_progress → done`, plus `cancelled`) and the minimum gates that govern each transition so authoring, execution, and closure live in non-overlapping skill territory.
+- Mandate the **consistency check**: before a feature transitions out of `draft`, it **MUST** be reviewed against the existing feature corpus and against the existing source-code surface for overlap, duplication, and drift; the check is delegated to the `feature-consistency-reviewer` agent and its findings **MUST** be recorded on the feature itself.
+- Anchor every feature back to one roadmap item (`R-<n>`) and one sprint (`<NNNN>`) so traceability flows roadmap → sprint → feature → acceptance criterion → deployable artefact without gaps.
+- Specify a clear acceptance-criteria contract: criteria are testable, individually checkable, and at least one criterion per sprint is required to verify the sprint's `value_statement` (the requirement is enforced sprint-side, but the **shape** of an acceptance criterion plus the **frontmatter marker** that flags the value-verifying criterion are defined here).
+- Stay portfolio-reusable: every project type the portfolio supports (Claude plugin, Python application, Python library, Node / TypeScript, CLI tool, documentation-only) can adopt the schema **unmodified**: the frontmatter schema and the body sections are identical across project types, project-type-specific guidance lives only in body content (Description language, Test hook conventions), and **MUST NOT** branch the schema or section list per project type.
+
+## Non-Goals
+
+- Defining roadmap, sprint, or release-artefact internals. Each is owned by its own sibling spec; this spec only declares the feature-side surface and the cross-references it carries.
+- Replacing test frameworks. Acceptance criteria reference tests, manual demo steps, or skill invocations; the feature spec doesn't run them, only enumerates and tracks them.
+- Mandating a specific implementation language or framework. The spec is about authoring and tracking shape, not about how the feature is built.
+- Substituting the `audience-identification` or audience-doc-author tooling. Feature documentation for end users belongs to the doc-author surface; the feature markdown is an internal planning artefact.
+- Substituting `continuous-improvement`, `spec-drift-audit`, or `spec-readiness`. Those govern process and spec hygiene; this spec governs feature artefact hygiene.
+- Replacing the `feature-consistency-reviewer` agent's logic. The agent's investigation surface (which paths to read, how to assess overlap) is its own concern; this spec only mandates **whether** the check happens and **which findings** get recorded.
+
+## Requirements
+
+### Directory layout and file shape
+
+- **MUST** place every feature at `project/features/<slug>.md`, where `<slug>` is an ASCII kebab-case summary of the feature title, stable across the feature's lifetime.
+- **MUST** keep exactly one markdown file per feature; feature content is never split across multiple files.
+- **MUST NOT** rename a feature's slug after it leaves `draft`; renames silently break sprint and roadmap back-references.
+- **SHOULD** keep `<slug>` short enough to be readable in directory listings (≤ 6 words kebab-cased is the target).
+
+### Frontmatter schema
+
+- **MUST** open the file with a YAML frontmatter fence carrying the following fields, in this order:
+  - `id` (string, required)—pattern `F-<n>`, monotonically assigned across the project, never reused;
+  - `title` (string, required)—one-line summary in the project's primary language;
+  - `status` (enum, required)—one of `draft`, `ready`, `in_progress`, `done`, `cancelled`;
+  - `roadmap_item` (string, required)—the `R-<n>` ID this feature decomposes; **MUST** match an entry in `project/roadmap.md`;
+  - `sprint` (integer or null, required)—the sprint number this feature is scheduled for; null while the feature is `draft` and during `ready` while the feature hasn't yet been adopted by a sprint. The field transitions from null to non-null when, and only when, the feature is added to a sprint's `features` list per `spec/project/sprint/`; the canonical write authority is `sprint-plan` (when scheduling ahead of activation) or `sprint-execute` (when picking the feature up mid-active-sprint), each of which **MUST** write `feature.sprint = N` in the same operation that adds `feature.id` to `sprints/N.features`. The field **MUST NOT** be set by hand or by any other skill, and the bidirectional invariant (feature side ↔ sprint side) is the canonical check;
+  - `created` (ISO date, required)—date the feature file was first written; never edited after creation;
+  - `ended` (ISO date or null, required)—date the feature reached either `done` or `cancelled` (both terminal states share this field, hence the neutral name); null until the feature terminates;
+  - `verifies_sprint_value` (string or null, required)—the acceptance-criterion identifier (`acceptance-<n>`) on this feature that, when checked, directly verifies the sprint's `value_statement`; non-null on at most one feature per sprint, null otherwise. The sibling `sprint` spec mandates that **at least one** feature in any closing sprint carries a non-null value here; combined with the at-most-one bound enforced feature-side (see §Acceptance-criteria contract and AC line below), the net constraint is exactly one. The write authority is `feature-decompose` (when the verifying criterion is identified at decomposition time) or `sprint-plan` (when the verifying criterion is reassigned during planning); the field **MUST** be non-null on exactly one feature per sprint **before** that sprint transitions to `review`;
+  - `consistency_check` (object, required)—see §Consistency-check schema below.
+- **MUST NOT** include effort estimates, points, or assignment fields beyond what's declared above; lints flag unknown keys.
+
+### Body sections
+
+- **MUST** carry the following level-2 sections in this order, even when empty (skills depend on stable section headings):
+  - `## Description`: one to three paragraphs describing the user-visible change; written in the project's primary language; phrased from the end-user perspective when possible.
+  - `## Acceptance criteria`: checklist of testable, individually checkable conditions; see §Acceptance-criteria contract for the per-item shape.
+  - `## Test hooks`: explicit list of which tests, skills, or manual demo steps validate which acceptance criteria. Each entry **MUST** carry three components: (a) the `acceptance-<n>` identifier it pins to; (b) the verification mechanism (test path, skill name, CLI command, or manual procedure); (c) a status token from the closed vocabulary `pending` (not yet executed), `passing` (executed and successful), `skipped` (intentionally not executed for this run with rationale), or `failing` (executed and unsuccessful). Format: `- **acceptance-<n>** — <mechanism> — <status>`. A hook is "resolved" for the lifecycle gate (see §Lifecycle and gates) only when its status is `passing` or `skipped`.
+  - `## Consistency notes`: populated by the consistency check (see §Consistency check); summarises the agent's findings and the resolution chosen for each finding.
+  - `## Risks`: known unknowns, blockers, or workarounds; **MAY** be empty for low-risk features.
+- **MAY** carry additional level-2 sections (`## Open questions`, `## References`) when the feature genuinely needs them; **MUST NOT** alter the order of the required sections to accommodate optional ones.
+
+### Acceptance-criteria contract
+
+- **MUST** state every acceptance criterion as a markdown checkbox bullet (`- [ ] …`), one criterion per bullet, atomic (a single check), testable (a reviewer can mark done/not done without ambiguity).
+- **MUST** assign a stable per-feature criterion identifier visible in the bullet text using the pattern `acceptance-<n>` (for example `- [ ] **acceptance-1** Sensor reading appears within 5 s after device discovery`); the identifier is what the `verifies_sprint_value` frontmatter field references and what `## Test hooks` entries pin against.
+- **MUST NOT** carry process-internal criteria ("PR approved", "merged to develop"); acceptance criteria are user-visible behaviour, not workflow gates.
+- **SHOULD** target three to seven criteria per feature; one is suspicious (under-specified), more than ten suggests the feature should be split.
+- **MUST NOT** rely on prose markers in bullet text to identify the value-verifying criterion; the only authoritative signal is the `verifies_sprint_value` frontmatter field. Authors **MAY** mention the verifying role in human-readable prose for reader clarity, but consuming skills **MUST** parse the frontmatter, not the bullet text.
+
+### Consistency check
+
+- **MUST** perform a consistency check before a feature transitions from `draft` to `ready`. The canonical performer is the `feature-consistency-reviewer` agent (per `spec/claude/agent-management/`); until that agent ships, an operator-driven manual pass following the same investigation surface and the same recording shape **MAY** satisfy this requirement, **provided** the manual pass is recorded with `agent_version: manual-<YYYY-MM-DD>` in `consistency_check` and the `## Consistency notes` section names the operator who performed it. Once the agent ships, the manual fallback **MUST** be removed and any feature that subsequently relies on the fallback constitutes a workflow-health finding. The check (whether agent or manual) reviews:
+  - the existing feature corpus under `project/features/` for overlapping or contradicting features;
+  - the existing source-code surface (the project's primary source roots, identified by repo conventions) for already-implemented behaviour that the new feature would re-implement; the source-code surface follows whichever primary-source layout `spec/project/project-structure/` recognises for the consuming repo, so for a Claude Code plugin repo the surface explicitly **includes** `skills/<name>/SKILL.md`, `agents/<name>.md`, and `.claude-plugin/plugin.json` (the plugin's executable behaviour lives in those files even though they're markdown), the same way it includes `src/`, `src/<component>/`, `custom_components/<name>/`, `playbooks/`, and `roles/` for repos using those layouts;
+  - the spec corpus under `spec/` for prior decisions that constrain this feature.
+- **MUST** record the agent's findings on the feature in the `## Consistency notes` body section and as a structured `consistency_check` frontmatter object with these fields:
+  - `performed_at` (ISO date, required)—when the check ran;
+  - `agent_version` (string, optional)—agent identifier so re-runs can be compared;
+  - `findings` (list, required)—each finding with `kind` (`overlap`, `duplication`, `drift`, `prior-art`, `clean`), `target` (file path or feature ID it relates to), and `resolution` (`merge-into <id>`, `supersede <id>`, `split-out <ids>`, `proceed`, `revisit-after <event>`).
+- **MUST** treat any finding with `kind: overlap` or `kind: duplication` as a blocker for the `draft → ready` transition unless its `resolution` is `proceed` with an explicit one-paragraph rationale in `## Consistency notes`.
+- **MUST** re-run the consistency check when, while the feature is in `ready` or `in_progress`, any of the following occur: the `## Description` section is changed by more than typo-level wording, an acceptance criterion is added or its core wording (excluding the checkbox state) is altered, the `roadmap_item` or `sprint` frontmatter field is changed, or a feature with overlapping scope is added or removed elsewhere in `project/features/`. The re-run **MUST** preserve historical findings (append a new `findings` block dated by `performed_at`, don't overwrite). Cosmetic edits (typo fixes, formatting, link target normalisation, the bullet checkbox flipping for an existing acceptance criterion) **MUST NOT** trigger a re-run.
+- **MUST** record findings inline on the feature (in `consistency_check` frontmatter and `## Consistency notes`), never as a separate `.audits/feature-consistency/` artefact. Unlike the transient `skill-review`/`agent-review` plans under `.audits/` (which `spec/claude/review-plan/` defines as deletable-on-completion working documents), consistency findings are durable, append-only feature metadata that gate the `draft → ready` lifecycle, so they live on the feature itself.
+- **MUST** keep the `consistency_check` object inline on the feature regardless of `findings` history length; externalising it to a separate file is settled-against, because findings gate the lifecycle and have to stay diffable on the feature itself.
+
+### Lifecycle and gates
+
+- **MUST** transition `status` only along these paths: `draft → ready`, `ready → in_progress`, `in_progress → done`, and `cancelled` reachable from any of `draft`, `ready`, `in_progress`. Direct `draft → in_progress`, `draft → done`, and `ready → done` are forbidden because they skip the consistency-check or the execution gate.
+- **MUST** require, before `draft → ready`: a non-empty `## Description`, at least one acceptance-criterion bullet, a populated `consistency_check` frontmatter, and a populated `## Consistency notes` section.
+- **MUST** require, before `ready → in_progress`: a non-null `sprint` value matching either the currently `active` sprint or the lowest-numbered `planned` sprint per the sibling `sprint` spec, and the feature listed in that sprint's `features` field. When the matched sprint is `planned`, `sprint-execute` automatically promotes it to `active` as a side effect of this transition (per `sprint` §Lifecycle); when another sprint is already `active`, the transition is rejected.
+- **MUST** require, before `in_progress → done`: every acceptance criterion checked, every test hook resolved (status `passing` or `skipped` per §Body sections), and the feature's sprint either `active` or `review`.
+- **MAY** transition to `cancelled` at any point before `done`; the transition **MUST** carry a one-paragraph rationale, placed in `## Risks` when the feature was cancelled before the consistency check ran (status `draft` at cancellation), and in `## Consistency notes` when the feature was cancelled at or after `ready` because the consistency check or a later finding revealed the feature shouldn't be built.
+
+### Roadmap, sprint, and source linkage
+
+- **MUST** ensure `roadmap_item` resolves to an `R-<n>` declared in `project/roadmap.md`; a feature with no roadmap link is invalid even when the originating motivation is "internal hardening"—declare a roadmap item for the hardening intent first.
+- **MUST** ensure that, when `sprint` is non-null, the referenced sprint file's `features` frontmatter list contains this feature's `id`; the back-reference is bidirectional and validated on every sprint and feature change.
+- **MUST** allow `## Test hooks` to point at source paths, test paths, or skill names; the spec doesn't constrain which mechanism a hook chooses, only that the mechanism is named explicitly so the consistency check can locate prior art.
+- **MAY** carry references to external issues (GitHub issues, project boards) in `## Description` or `## References`; those references are documentation, never authoritative.
+
+### Hobby-scale variability
+
+- **MUST NOT** require effort estimates, due dates, or velocity tracking on features; like roadmap items and sprints, features are author-paced.
+- **SHOULD** tolerate long stretches between consistency check and execution; if more than two sprints pass without execution, the consistency check **SHOULD** be re-run before `ready → in_progress`.
+- **MAY** mark a feature `cancelled` when the consistency check reveals that an existing feature already covers it; cancellation with `resolution: merge-into <id>` is a first-class outcome, not a failure state.
+- **MUST** apply the identical schema and lifecycle to documentation-only features (a how-to page, a runbook); the no-per-type-branching rule (Goal 6) admits no doc-feature exception, and a doc feature remains an internal planning artefact carrying the same acceptance-criteria, test-hook, and consistency contract as any other feature.
+
+## Acceptance Criteria
+
+- [ ] Every feature exists as exactly one file at `project/features/<slug>.md` with a stable slug; no slug is renamed after the feature leaves `draft`.
+- [ ] Every feature's frontmatter carries the nine schema fields (`id`, `title`, `status`, `roadmap_item`, `sprint`, `created`, `ended`, `verifies_sprint_value`, `consistency_check`) in the declared order; lints flag unknown keys and reject `closed` as a frontmatter field name (the field is named `ended`).
+- [ ] Every feature's body carries the five required level-2 sections (`Description`, `Acceptance criteria`, `Test hooks`, `Consistency notes`, `Risks`) in the declared order; missing sections fail validation.
+- [ ] Every acceptance-criterion bullet uses the `**acceptance-<n>**` identifier pattern and is atomic, testable, and user-visible (not a workflow gate); no bullet carries an inline value-verifier marker (the only authoritative signal is the `verifies_sprint_value` frontmatter field).
+- [ ] Every `## Test hooks` entry pins to an `acceptance-<n>` identifier, names a verification mechanism, and carries a status token from the closed vocabulary (`pending`, `passing`, `skipped`, `failing`); entries lacking any of the three components fail validation.
+- [ ] No feature transitions `draft → ready` without a populated `consistency_check` frontmatter object whose `findings` array is non-empty (a clean run still records `kind: clean`) and a populated `## Consistency notes` section.
+- [ ] No feature transitions `ready → in_progress` while another sprint than the one referenced by its `sprint` field is `active`; the gate is enforced by `sprint-execute` and triggers the planned-to-active promotion when applicable.
+- [ ] No feature transitions `in_progress → done` while any acceptance-criterion bullet remains unchecked or any test hook's status is `pending` or `failing`.
+- [ ] No direct transitions occur for `draft → in_progress`, `draft → done`, or `ready → done`; transition-graph violations are rejected by the consuming skills.
+- [ ] Every `consistency_check.findings` entry whose `kind` is `overlap` or `duplication` either has a non-`proceed` resolution or carries a one-paragraph rationale in `## Consistency notes` justifying the `proceed` choice.
+- [ ] At most one feature per sprint carries a non-null `verifies_sprint_value`; sprints that close with zero or more than one such feature fail sprint-side validation per the sibling `sprint` spec.
+- [ ] Every cancelled feature carries a one-paragraph rationale: in `## Risks` when cancelled in `draft`, in `## Consistency notes` when cancelled in `ready` or `in_progress`. Missing rationale fails validation.
+- [ ] No feature schema branches per project type; the schema and the body section list are identical across Claude plugin, Python application, Python library, Node / TypeScript, CLI tool, and documentation-only repos.
+
+## Open Questions
+
+- Cross-feature dependencies (`F-7 needs F-3 first`) carry no schema field today; sprint membership plus the `roadmap_item` link express the only sequencing that exists. Revisit when a real feature chain appears that sprint ordering can't express—concretely, two features land where the later one's `## Acceptance criteria` or `## Test hooks` reference a behaviour the earlier one introduces, both are scheduled into the SAME `sprint` (so sprint ordering can't sequence them), AND the consistency check can't capture the ordering as a `prior-art`/`revisit-after` finding. The first such occurrence unblocks adding `depends_on` to BOTH the feature schema and the sibling `sprint` spec in lockstep (the sprint spec carries no dependency or ordering field today, so a feature-side-only addition would be a one-sided invariant).

--- a/spec/project/mission/de.md
+++ b/spec/project/mission/de.md
@@ -1,0 +1,130 @@
+# Projekt-Mission
+
+Status: draft
+
+## Kontext
+
+Leser: Repo-Maintainer von Hobby-Projekten im nolte-Portfolio, die die Skills `mission-define` und `mission-revise` aufrufen (sobald diese existieren), die Operatoren, die `mvp_status` eines Projekts bei der Stabilisierung umlegen, sowie die Implementierer dieser Skills, die gegen das hier definierte Schema bauen.
+
+Bestehende Portfolio-Specs regeln, welche Arbeit ansteht (`roadmap`), wie Arbeit gruppiert wird (`sprint`), die Ausführungseinheit (`feature`) und wie Releases ausgeliefert werden (`release-artifact`, `release-automation`). Was bisher nicht erklärt ist: **warum das Projekt überhaupt existiert, für wen, und welche Teilmenge der eingereihten Arbeit das Minimum ist, das diesen Zweck wirklich erfüllt**. Diese Spec füllt diese Lücke. Ein Mission Statement im nolte-Portfolio ist ein über Markdown verwalteter, audience-spezifisch zugeschnittener, SMART-konformer Satz, der die Roadmap verankert: er bindet jedes eingereihte Item zurück an einen erklärten Zweck, trennt das **MVP** (die minimale nutzbare Oberfläche, die die Mission belegt) von der **Post-MVP-Abgrenzung** (explizit benannt, damit die Grenze sichtbar bleibt), und macht Post-MVP-Arbeit von der MVP-Stabilisierung abhängig. Die Pflicht zum Audience-Tailoring ist tragend: ein Mission Statement, das nicht auf das Audience-Artefakt des Projekts auflöst, ist ein privates Ziel, keine Portfolio-Mission.
+
+## Ziele
+
+- Die Datei-Form einer Projekt-Mission als eine einzige Markdown-Datei unter `project/mission.md` festlegen, parallel zu `project/roadmap.md` und `project/goals.md`, mit stabilem Frontmatter-Schema und verpflichtenden Body-Sections, damit konsumierende Skills die Mission deterministisch parsen, ändern und validieren können.
+- SMART für das Hobby-Skala-Portfolio formalisieren: jeder der fünf Buchstaben wird zu einer eigenen prüfbaren Anforderung, wobei der **Time-bound**-Anteil als Outcome-oder-MVP-Completion-Referenz ausgedrückt wird, nicht als Kalenderdatum.
+- Die **MVP-Definition** festlegen als minimale Teilmenge der Roadmap-Items, deren Abschluss die Mission über den bestehenden `verifies_sprint_value`-Mechanismus aus der Geschwister-Spec `feature` belegt; hier wird kein neuer Verifikations-Mechanismus eingeführt.
+- Das **Stabilisierungs-Gate** festlegen: Post-MVP-Roadmap-Items (`mvp: false`) **DÜRFEN NICHT [MUST NOT]** auf `status: active` wechseln, bevor das MVP als ganzes **stabilisiert** ist, und diese Spec definiert die exakten Bedingungen, unter denen der Operator `mvp_status` auf `stabilised` umlegen darf.
+- **Audience-Tailoring** erzwingen: für jede Audience in `audiences` **MUSS [MUST]** der Body erklären, was das MVP dieser Audience liefert; eine Audience ohne zugehörigen Tailoring-Absatz schlägt die Validierung.
+- Portfolio-weit wiederverwendbar bleiben: jeder im Portfolio unterstützte Projekttyp (Claude-Plugin, Python-Anwendung, Python-Bibliothek, Node / TypeScript, CLI-Tool, dokumentations-only) kann das Schema unverändert übernehmen; typ-spezifische Hinweise leben nur in Body-Inhalten, niemals im Frontmatter-Schema.
+
+## Nicht-Ziele
+
+- Roadmap-, Goals-, Sprint-, Feature- oder Release-Artefakt-Innenleben festzulegen. Jedes davon gehört seiner eigenen Geschwister-Spec; diese Spec erklärt nur die Mission-seitige Oberfläche und die Querverweise, die sie trägt.
+- `audience-identification` zu ersetzen. Audience-Aufzählung, -Charakterisierung und -Bestätigung gehören dorthin; diese Spec konsumiert das resultierende Artefakt und **DARF NICHT [MUST NOT]** Audiences inline erfinden.
+- `continuous-improvement` zu ersetzen. Diese Spec führt ereignis- und kalendergetriebene Audits über die Prozess-Hygiene des gesamten Portfolios; Mission-seitiges Authoring ist Produkt-formgebend, nicht Prozess-formgebend, und die beiden Kadenzen laufen parallel ohne sich zu ersetzen.
+- Eine Kalender-Deadline für die Mission-Erfüllung zu erzwingen. Hobby-Projekte tragen laut Geschwister-Specs `sprint` und `roadmap` keine Daten; diese Spec übernimmt diese Einschränkung und lehnt kalender-gebundene Time-bound-Klauseln ab.
+- Portfolio-Strategiedokumente (Vision-Decks, OKR-Sheets, Product-Briefs) zu ersetzen. Die Mission-Datei ist ein Markdown-Artefakt unter Versionskontrolle neben dem Code, den sie beschreibt; Querverweise auf externe Dokumente sind erlaubt, aber niemals autoritativ.
+- Ein Stakeholder-Sign-off-Ritual zu erzwingen, bevor Mission-Schreibvorgänge akzeptiert werden. Hobby-Projekte tragen keinen Stakeholder-Prozess; die Anforderungen Audience-Tailoring + Outcome-Verknüpfung + verifizierendes Feature ersetzen zusammen das, was ein Enterprise-Sign-off abfangen würde.
+
+## Anforderungen
+
+### Verzeichnislayout und Datei-Form
+
+- **MUSS [MUST]** die Mission unter `project/mission.md` ablegen, genau eine Datei pro Projekt, niemals gesplittet.
+- **DARF NICHT [MUST NOT]** die Datei unter `docs/` oder einem anderen Unterverzeichnis verschachteln; die Mission ist ein Top-Level-Orientierungspunkt parallel zu `spec/`, `tests/` und den übrigen `project/`-Planungsartefakten.
+- **KANN [MAY]** in Repositories fehlen, die das Planungs-Toolset noch nicht eingeführt haben; Abwesenheit ist laut Geschwister-Spec `project-structure` zulässig. Sobald die Datei existiert, gilt jede Anforderung dieser Spec.
+
+### Frontmatter-Schema
+
+- **MUSS [MUST]** die Datei mit einem YAML-Frontmatter-Fence öffnen, der folgende Felder in dieser Reihenfolge trägt:
+  - `mission_statement` (String, verpflichtend, nicht leer) — der eigentliche SMART-konforme Satz in der Hauptsprache des Projekts; ein Satz, keine Markdown-Formatierung über Inline-Interpunktion hinaus.
+  - `relevant_outcomes` (Liste von Outcome-IDs, verpflichtend, nicht leer) — jeder Eintrag **MUSS [MUST]** ein in `project/goals.md` definiertes `O-<n>` matchen, laut Geschwister-Spec `roadmap`.
+  - `audiences` (Liste von Audience-Bezeichnern, verpflichtend, nicht leer) — jeder Eintrag **MUSS [MUST]** zu einem Audience-Eintrag im Audience-Artefakt des Projekts matchen (`AUDIENCES.md` oder die laut `audience-identification` vom konsumierenden Repo deklarierte Stelle).
+  - `verifies_via` (String, verpflichtend) — Muster `<feature-id>:acceptance-<n>` (zum Beispiel `F-3:acceptance-2`), benennt das Feature, dessen Frontmatter-Feld `verifies_sprint_value` auf das Akzeptanzkriterium zeigt, das die Erfüllung der Mission belegt; das genannte Feature **MUSS [MUST]** unter `project/features/` existieren und der genannte Akzeptanz-Identifier **MUSS [MUST]** auf diesem Feature existieren.
+  - `time_bound` (Objekt, verpflichtend) — eine von zwei Formen: `{ kind: outcome, ref: O-<n> }` (Time-bound an ein bestimmtes Outcome aus `goals.md`) oder `{ kind: mvp_completion }` (Time-bound an den Moment, in dem `mvp_status` `achieved` erreicht); kalender-gebundene Formen sind verboten.
+  - `mvp_status` (Enum, verpflichtend) — einer von `defining` (der MVP-Scope wird gerade geformt), `in_progress` (mindestens ein MVP-Item ist `active` oder `done`), `achieved` (jedes MVP-Item ist `done` und das verifizierende Akzeptanzkriterium ist abgehakt), `stabilised` (der Zustand `achieved` hat über einen vollen Folgesprint laut §Stabilisierungs-Gate gehalten).
+  - `created` (ISO-Datum, verpflichtend) — Datum, an dem die Mission-Datei erstmals geschrieben wurde; nach Erstellung nie editiert.
+  - `revised_at` (ISO-Datum oder null, verpflichtend) — Datum der jüngsten substantiellen Revision (Änderung des Statements, der Audiences, der Verifikation oder der Time-bound-Klausel); null, solange die Mission-Datei im Original-Schreibstand ist.
+- **DARF NICHT [MUST NOT]** Kalender-Deadlines, OKR-Werte, KPI-Felder oder Stakeholder-Zuweisungs-Felder über die oben deklarierten hinaus enthalten; Lints flaggen unbekannte Schlüsselwörter.
+
+### Body-Sections
+
+- **MUSS [MUST]** folgende Level-2-Sections in dieser Reihenfolge tragen, auch wenn der Inhalt knapp ist (Skills hängen an stabilen Section-Überschriften):
+  - `## Statement` — das Mission Statement als Prosa wiederholt, unmittelbar gefolgt von einer SMART-Aufschlüsselung (ein kurzer Absatz pro Buchstabe, der benennt, welches Frontmatter-Feld diesen Buchstaben verankert — siehe §SMART-Vertrag).
+  - `## Audiences` — ein Absatz pro Audience aus dem Frontmatter-Feld `audiences`, der die Audience benennt und beschreibt, was das MVP dieser Audience konkret liefert; keine Audience darf im Frontmatter ohne zugehörigen Absatz hier auftauchen, und kein Absatz darf eine Audience nennen, die nicht im Frontmatter steht.
+  - `## Verification` — ein kurzer Prosa-Verweis auf das Feature und Akzeptanzkriterium aus `verifies_via`, mit Wiederholung des Kriterium-Texts wortgetreu, damit die Mission-Datei lesbar bleibt, ohne den Feature-Bestand durchzugehen.
+  - `## Source` — der Audit-Trail: welches Audience-Artefakt konsultiert wurde (Pfad plus Last-Commit-SHA zum Schreibzeitpunkt), welche `goals.md`-Outcomes referenziert wurden, wer oder was die Mission verfasst hat (Operator-Name, Skill-Version oder Commit-SHA der mission-erzeugenden Änderung).
+- **KANN [MAY]** eine zusätzliche `## Open questions`-Section für offene Authoring-Entscheidungen tragen; **DARF NICHT [MUST NOT]** die Reihenfolge der vier Pflicht-Sections wegen optionaler ändern.
+
+### SMART-Vertrag
+
+Das Mission Statement **MUSS [MUST]** jede der folgenden fünf Bedingungen erfüllen, einzeln gegen die genannten Artefakte prüfbar:
+
+- **Specific** — das `mission_statement` benennt sowohl **was** das Projekt tut als auch **für wen**; das **für wen** **MUSS [MUST]** auf einen oder mehrere Einträge in der Frontmatter-Liste `audiences` auflösen. Eine Mission, deren Audience implizit ist („für Nutzer"), schlägt diese Bedingung; der Audience-Bezeichner ist explizit.
+- **Measurable** — das Frontmatter-Feld `verifies_via` benennt genau ein Feature und genau ein Akzeptanzkriterium auf diesem Feature. Sobald dieses Akzeptanzkriterium abgehakt ist (laut Geschwister-Spec `feature`), ist die Mission messbar erfüllt. Kein anderer Verifikations-Mechanismus wird eingeführt.
+- **Achievable** — jedes Roadmap-Item mit `mvp: true` trägt `detail: fine` und ein nicht-null `target_sprint` laut Geschwister-Spec `roadmap`, und die Anzahl der MVP-Items **SOLLTE [SHOULD]** grob der Kapazität von zwei bis fünf Sprints entsprechen. Ein unbegrenzter MVP-Scope (jedes Roadmap-Item mit `mvp: true` geflaggt) hebelt die Erreichbarkeit aus und **MUSS [MUST]** von konsumierenden Skills mit einem wortgetreuen Fehler abgelehnt werden.
+- **Relevant** — die Frontmatter-Liste `relevant_outcomes` ist nicht leer und jeder Eintrag löst auf ein Outcome in `project/goals.md` auf. Eine Mission, die nicht auf mindestens ein deklariertes Outcome zurückbindet, schlägt diese Bedingung.
+- **Time-bound** — das Frontmatter-Objekt `time_bound` ist eines von `{ kind: outcome, ref: O-<n> }` oder `{ kind: mvp_completion }`. Kalenderdaten und Freitext-Deadlines werden abgelehnt. Die Bindung ist absichtlich outcome-förmig, weil Hobby-Sprint-Dauer laut Geschwister-Spec `sprint` variabel ist; diese Spec übernimmt diese Einschränkung.
+
+### MVP-Definition und -Abgrenzung
+
+- **MUSS [MUST]** das MVP als die Menge der Roadmap-Items in `project/roadmap.md` definieren, deren YAML-Block `mvp: true` trägt. Der autoritative Ort des Flags ist die Roadmap; die Mission-Spec ist die Autorität für die Semantik des Flags.
+- **MUSS [MUST]** jedes Roadmap-Item mit `mvp: false` als **Post-MVP** behandeln und damit als optional für die Mission-Erfüllung. Post-MVP-Items bleiben explizit in der Roadmap, damit die Grenze zwischen Minimum und zusätzlichem Scope sichtbar bleibt — ein Item zu benennen, aber mit `mvp: false` zu flaggen, ist die kanonische Art zu sagen „wir wissen davon, es ist nicht Teil des MVP, es wartet".
+- **MUSS [MUST]** für jedes Roadmap-Item mit `mvp: true` verlangen, dass mindestens eines seiner Features (laut Geschwister-Spec `feature`) `verifies_sprint_value` nicht-null deklariert, sobald dieses Feature im MVP-abschließenden Sprint ausgeliefert wird. Über den gesamten MVP-Scope hinweg **MUSS [MUST]** genau ein Feature dasjenige sein, das im `verifies_via`-Feld der Mission benannt ist; dieses Feature ist das **mission-verifizierende Feature**.
+- **DARF NICHT [MUST NOT]** zulassen, dass ein Roadmap-Item sein `mvp`-Flag von `true` auf `false` umschaltet, nachdem das Item `status: active` erreicht hat; sobald ein Item in die MVP-Ausführung tritt, ist das nachträgliche Entfernen aus dem MVP-Scope verboten, weil es die Erreichbarkeits-Schranke des SMART-Vertrags brechen würde. Items **KÖNNEN [MAY]** vor der Stabilisierung jederzeit von `mvp: false` auf `mvp: true` umschalten.
+
+### Stabilisierungs-Gate
+
+- **MUSS [MUST]** das MVP genau dann als **stabilisiert** behandeln, wenn jede der folgenden Bedingungen gleichzeitig erfüllt ist:
+  - jedes Roadmap-Item mit `mvp: true` trägt `status: done`;
+  - der Sprint, der das letzte MVP-Item geschlossen hat, ist selbst laut Geschwister-Spec `sprint` `status: closed`;
+  - ein voller Folgesprint hat `status: closed` erreicht (oder `cancelled` aus MVP-fremden Gründen), ohne dass ein MVP-Item auf `status: active` zurückgekehrt ist;
+  - keine Defekt-Fix-Arbeit, die ein MVP-Item betrifft, ist laut Geschwister-Spec `feature` aktuell in `status: in_progress`.
+- **DARF NICHT [MUST NOT]** zulassen, dass ein Post-MVP-Roadmap-Item (`mvp: false`) `proposed → active` übergeht, solange `mvp_status` einer von `defining`, `in_progress` oder `achieved` ist. Der Übergang ist nur zulässig, wenn `mvp_status: stabilised`.
+- **MUSS [MUST]** verlangen, dass der Operator (oder ein zukünftiger Automations-Skill) `mvp_status` explizit auf `stabilised` umlegt; das Umlegen **DARF NICHT [MUST NOT]** still aus der Erfüllung der obigen Bedingungen abgeleitet werden. Der Schalter-Akt protokolliert die Entscheidung; die Bedingungen rechtfertigen sie.
+- **MUSS [MUST]** `mvp_status: stabilised → in_progress` zurücksetzen, sobald ein MVP-Item auf `status: active` zurückgeht (zum Beispiel weil ein Defekt nach der Stabilisierung auftaucht); das Gate greift dann erneut, und Post-MVP-Items, die zum Zeitpunkt der Rücksetzung bereits in `status: active` sind, **KÖNNEN [MAY]** zu Ende geführt werden, aber kein neues Post-MVP-Item **DARF [MUST]** gestartet werden, bevor die Stabilisierung wiederhergestellt ist.
+- **KANN [MAY]** die Stabilisierungs-Belege (die Sprint-Nummer, die die Bedingung „ein voller Folgesprint" erfüllt hat, das Datum der Operator-Entscheidung) für den Audit-Trail in `## Source` festhalten.
+
+### Audience-Tailoring
+
+- **MUSS [MUST]** für jede Audience in `audiences` einen Absatz in `## Audiences` verlangen, der den Audience-Bezeichner benennt und beschreibt, was das MVP dieser Audience konkret liefert. Eine reine Liste von Audience-Namen ohne zugehörige Absätze schlägt die Validierung.
+- **DARF NICHT [MUST NOT]** in `## Audiences` eine Audience nennen, die nicht auch in der Frontmatter-Liste `audiences` steht, und umgekehrt; die beiden Oberflächen werden bidirektional validiert.
+- **SOLLTE [SHOULD]** jeden Per-Audience-Absatz kurz halten (drei bis fünf Sätze); braucht eine einzelne Audience mehr, ist die Audience selbst wahrscheinlich unter-spezifiziert, und `audience-identification` sollte erneut laufen, statt die Mission-Datei zu strecken.
+- **KANN [MAY]** Audiences gruppieren, wenn deren MVP-Lieferumfang identisch ist (ein Absatz, der die zwei Audiences benennt und den geteilten Lieferumfang beschreibt), aber jeder Audience-Bezeichner **MUSS [MUST]** trotzdem namentlich erscheinen, und die Gruppierungs-Begründung **MUSS [MUST]** in demselben Absatz stehen.
+
+### Cross-Spec-Verknüpfung
+
+- **MUSS [MUST]** `audience-identification` als Autorität für Form und Inhalt des Audience-Artefakts behandeln. Hat das Projekt kein Audience-Artefakt, ist Mission-Authoring blockiert; der Skill `audience-identify` **MUSS [MUST]** zuerst dispatched werden, identisch zur Regel, die heute schon für Outcome-Authoring in der Geschwister-Spec `roadmap` gilt.
+- **MUSS [MUST]** die Geschwister-Spec `roadmap` als Autorität für den Ort des `mvp`-Felds im Roadmap-Item-YAML-Schema behandeln; diese Spec ist die Autorität für die Semantik des Felds. Die beiden Oberflächen verweisen explizit aufeinander, und der Querverweis ist pro Belang einseitig (Ort → roadmap, Semantik → mission).
+- **MUSS [MUST]** die Geschwister-Spec `feature` als Autorität für `verifies_sprint_value` behandeln; diese Spec konsumiert den Mechanismus und **DARF NICHT [MUST NOT]** ihn neu definieren.
+- **MUSS [MUST]** `goals.md` (geregelt von `roadmap`) als Autorität für Outcome-IDs behandeln; diese Spec verweist nur auf sie.
+
+### Hobby-Skala-Varianz
+
+- **DARF NICHT [MUST NOT]** Aufwandsschätzungen, Kalender-Deadlines, Velocity-Metriken oder Stakeholder-Sign-off-Felder an der Mission-Datei verlangen; der oben festgelegte SMART-Vertrag ersetzt bereits, was diese in einem Enterprise-Kontext abfangen würden.
+- **SOLLTE [SHOULD]** lange Strecken zwischen Mission-Revision und MVP-Erfüllung tolerieren; ein unverändertes `mission_statement` ist der korrekte Zustand, solange die Mission noch beschreibt, was das Projekt tut.
+- **KANN [MAY]** das Mission Statement jederzeit vor `mvp_status: stabilised` revidieren; Revisionen nach der Stabilisierung **MÜSSEN [MUST]** eine ein-absätzige Begründung in `## Source` tragen, weil sie umdeuten, wofür das stabilisierte MVP gut war.
+
+## Akzeptanzkriterien
+
+- [ ] `project/mission.md` existiert im Repo-Root jedes adoptierenden Projekts; verschachtelte oder alternative Orte schlagen die Validierung.
+- [ ] Das Mission-Frontmatter trägt die acht verpflichtenden Felder (`mission_statement`, `relevant_outcomes`, `audiences`, `verifies_via`, `time_bound`, `mvp_status`, `created`, `revised_at`) in der festgelegten Reihenfolge; Lints flaggen unbekannte Schlüsselwörter und lehnen jedes Kalenderdatum-Deadline-Feld jenseits von `created` und `revised_at` ab.
+- [ ] Der Mission-Body trägt die vier verpflichtenden Level-2-Sections (`Statement`, `Audiences`, `Verification`, `Source`) in der festgelegten Reihenfolge; fehlende Sections schlagen die Validierung.
+- [ ] Jede Audience in `audiences` löst auf einen Eintrag im Audience-Artefakt des Projekts auf und hat einen zugeschnittenen Absatz in `## Audiences`; reine Audience-Listen oder verwaiste Absätze schlagen die Validierung.
+- [ ] Jedes Outcome in `relevant_outcomes` löst auf ein `O-<n>` in `project/goals.md` auf; eine leere Liste oder ein nicht auflösender Eintrag schlägt die Validierung.
+- [ ] `verifies_via` löst auf eine Feature-Datei unter `project/features/` auf, deren Frontmatter `verifies_sprint_value` mit dem benannten Akzeptanz-Identifier deklariert; gebrochene Referenzen schlagen die Validierung.
+- [ ] `time_bound` ist eine von `{ kind: outcome, ref: O-<n> }` oder `{ kind: mvp_completion }`; jede andere Form schlägt die Validierung, und Kalenderdatum-Formen werden mit einem wortgetreuen Fehler abgelehnt.
+- [ ] Kein Post-MVP-Roadmap-Item (`mvp: false`) ist in `status: active`, solange `mvp_status` einer von `defining`, `in_progress` oder `achieved` ist; der konsumierende Skill lehnt den Übergang mit einem wortgetreuen Fehler ab, der diese Spec zitiert.
+- [ ] Jedes Roadmap-Item mit `mvp: true` trägt `detail: fine` und ein nicht-null `target_sprint`; Lints schlagen sonst fehl.
+- [ ] Kein Roadmap-Item kippt sein `mvp`-Flag von `true` auf `false`, nachdem es `status: active` erreicht hat; die umgekehrte Richtung (`false → true`) ist nur vor der Stabilisierung erlaubt.
+- [ ] `mvp_status` übergeht nur entlang des legalen Pfads `defining → in_progress → achieved → stabilised`, mit dem Rückweg `stabilised → in_progress`, sobald ein MVP-Item zurückgeht; jeder andere Übergang schlägt die Validierung.
+- [ ] Wenn `mvp_status: stabilised`, ist jedes Roadmap-Item mit `mvp: true` in `status: done`, und ein voller Folgesprint hat geschlossen, ohne dass ein MVP-Item zurückgegangen ist; der konsumierende Skill verifiziert die Bedingungen, bevor er den Operator-Schalter akzeptiert.
+- [ ] `audience-identification` wird vor dem Mission-Authoring auf einem frischen Repo ohne Audience-Artefakt ausgelöst; fehlende Audiences blockieren Mission-Schreibvorgänge genauso, wie sie laut Geschwister-Spec `roadmap` Outcome-Schreibvorgänge blockieren.
+- [ ] Keine Mission-Revision nach `mvp_status: stabilised` ohne einen ein-absätzigen Begründungs-Block in `## Source`; fehlende Begründung schlägt die Validierung.
+
+## Offene Fragen
+
+- Soll das Feld `verifies_via` irgendwann mehrere Feature-plus-Kriterium-Paare zulassen (eine Liste statt eines einzelnen Strings), damit zusammengesetzte Missionen, deren Verifikation tatsächlich auf zwei Features fällt, ausdrückbar bleiben? Default: `verifies_via` als einzelnen String `<feature-id>:acceptance-<n>` belassen (die eigene `project/mission.md` dieses Repos hat einen vollständigen Zyklus `defining → in_progress → achieved → stabilised` auf einem einzigen Paar durchlaufen, der Single-Pair-Default ist also validiert, nicht bloß hypothetisch). Revisitieren, wenn: eine reale `project/mission.md` verfasst wird, deren MVP-Scope Roadmap-Items umspannt, die tatsächlich in unterschiedlichen Sprints schließen, sodass kein einzelner Sprint das eine wert-verifizierende Feature tragen kann, UND der Operator zeigen kann, dass sich der Wert nicht auf ein Akzeptanzkriterium kollabieren lässt — konkret, wenn ein `mission-define`- oder `mission-revise`-Lauf blockiert wird, weil zwei verschiedene `verifies_sprint_value`-Features in zwei verschiedenen geschlossenen Sprints beide für dieselbe Mission tragend sind.
+- Soll die Bedingung „ein voller Folgesprint" im Stabilisierungs-Gate pro Projekt konfigurierbar sein (manche Projekte wollen vielleicht zwei)? Default: die feste Konstante von einem vollen Folgesprint belassen und kein Feld `stabilisation_soak_sprints` hinzufügen (Sprint 0002 dieses Repos hat den Soak für das in Sprint 0001 geschlossene MVP ohne Regression erfüllt, der Default hat also positive Nutzungsdaten hinter sich). Revisitieren, wenn: eine reale `project/mission.md` eine Post-Stabilisierungs-Regression zeigt, die ein einzelner Folge-Soak-Sprint nachweislich nicht abgefangen hat — ein MVP-Item, das im zweiten Post-MVP-Sprint nach dem Umlegen auf `stabilised` auf `status: active` zurückgeht — und damit belegt, dass ein Sprint für dieses Projekt zu kurz war.
+- Soll der Rückweg `mvp_status: stabilised → in_progress` automatisch jedes Post-MVP-Item, das bereits in `status: active` ist, anhalten, oder nur neue Starts blockieren? Default: die weichere Regel aus §Stabilisierungs-Gate belassen — ein Rückweg blockiert neue Post-MVP-Starts, lässt aber Post-MVP-Items im Flug zu Ende laufen, ohne Automation, die aktive Items zwangsweise anhält. Revisitieren, wenn: ein realer Post-Stabilisierungs-Rückweg auftritt (`stabilised → in_progress` in irgendeiner `project/mission.md` §Source protokolliert) UND eine Defekt-Postmortem zeigt, dass das Zu-Ende-laufen-Lassen eines Post-MVP-Items im Flug während des Rückwegs die Regression maskiert oder verstärkt hat. Bisher wurde im Portfolio kein Rückweg beobachtet.
+- Soll die Spec irgendwann einen maschinen-lesbaren Mission-Coverage-Report tragen (welche Audiences das MVP bedient, mit Verifikations-Status pro Audience)? Default: den Report weiter verschieben und ihn, wenn er kommt, als generiertes Artefakt statt als verfasstes Frontmatter bauen (die Bedingung „mindestens ein Projekt hat einen vollen Mission-Zyklus durchlaufen" ist bereits erfüllt, die Verschiebung ruht also allein auf dem fehlenden nachgelagerten Konsumenten). Revisitieren, wenn: ein benannter nachgelagerter Konsument Per-Audience-MVP-Verifikations-Status verlangt, der an die Mission statt an das Release-Audience-Artefakt gekoppelt ist — konkret, wenn die Subsection `## Audiences served` von `release-skill-layer` Skill A oder ein zukünftiger `audience-doc-author`-Schritt geändert wird, um `## Audiences` und `verifies_via` aus `project/mission.md` für den Per-Audience-Verifikations-Status zu lesen. Heute konsumiert keine Spec die Mission für Coverage; `release-skill-layer` mappt Audiences aus dem Release-Audience-Artefakt, nicht aus der Mission.

--- a/spec/project/mission/en.md
+++ b/spec/project/mission/en.md
@@ -1,0 +1,130 @@
+# Project Mission
+
+Status: draft
+
+## Context
+
+Readers: repo maintainers of hobby-scale nolte projects who invoke the `mission-define` and `mission-revise` skills (when those exist), the operators who flip a project's `mvp_status` at stabilisation, plus the implementing authors writing those skills against this schema.
+
+Existing portfolio specs cover what work is queued (`roadmap`), how work is grouped (`sprint`), the unit of execution (`feature`), and how releases ship (`release-artifact`, `release-automation`). What's not yet declared is **why the project exists at all, for whom, and which subset of the queued work is the minimum that genuinely fulfils that purpose**. This spec fills that gap. A mission statement in the nolte portfolio is a markdown-tracked, audience-tailored, SMART-shaped sentence that anchors the roadmap: it ties every queued item back to a stated purpose, distinguishes the **MVP** (the minimum useful surface that proves the mission) from **post-MVP** delimitation (named explicitly so the boundary stays visible), and gates post-MVP work on MVP stabilisation. The audience-tailoring requirement is load-bearing: a mission statement that doesn't resolve back to the project's audience artefact is a private goal, not a portfolio mission.
+
+## Goals
+
+- Define the on-disk shape of a project mission as a single markdown file at `project/mission.md`, parallel to `project/roadmap.md` and `project/goals.md`, with a stable frontmatter schema and required body sections so consuming skills can parse, mutate, and validate the mission deterministically.
+- Formalise SMART for the hobby-scale portfolio: each of the five letters becomes its own checkable requirement, with the **Time-bound** anchor expressed as an outcome-or-MVP-completion reference rather than a calendar date.
+- Specify the **MVP definition** as the minimum subset of roadmap items whose completion verifies the mission via the existing `verifies_sprint_value` mechanism declared in the sibling `feature` spec; no new verification mechanism is introduced here.
+- Specify the **stabilisation gate**: post-MVP roadmap items (`mvp: false`) **MUST NOT** advance to `status: active` until the MVP as a whole is **stabilised**, and this spec defines the exact conditions under which the operator may flip `mvp_status` to `stabilised`.
+- Mandate **audience tailoring**: for every audience listed in `audiences`, the body **MUST** explain what the MVP delivers to that audience; an audience listed without a tailored paragraph fails validation.
+- Stay portfolio-reusable: every project type the portfolio supports (Claude plugin, Python application, Python library, Node / TypeScript, CLI tool, documentation-only) can adopt the schema unmodified; project-type-specific guidance lives only in body content, never in the frontmatter schema.
+
+## Non-Goals
+
+- Defining roadmap, goals, sprint, feature, or release-artefact internals. Each is owned by its own sibling spec; this spec only declares the mission-side surface and the cross-references it carries.
+- Substituting `audience-identification`. Audience enumeration, characterisation, and confirmation are its concern; this spec consumes the resulting artefact and **MUST NOT** invent audiences inline.
+- Substituting `continuous-improvement`. That spec runs event- and calendar-driven audits over the whole portfolio's process hygiene; mission-side authoring is product-shaping, not process-shaping, and the two cadences run in parallel without replacing each other.
+- Mandating a calendar deadline for mission completion. Hobby-scale projects don't carry dates per the sibling `sprint` and `roadmap` specs; this spec inherits that constraint and rejects calendar-anchored Time-bound clauses.
+- Replacing portfolio strategy documents (vision decks, OKR sheets, product briefs). The mission file is a markdown artefact under version control next to the code it describes; cross-references to external documents are allowed but never authoritative.
+- Mandating a stakeholder sign-off ritual before mission writes are accepted. Hobby-scale projects don't carry a stakeholder process; the audience-tailoring + outcome-linkage + verifying-feature requirements together replace what an enterprise sign-off would catch.
+
+## Requirements
+
+### Directory layout and file shape
+
+- **MUST** place the mission at `project/mission.md`, exactly one file per project, never split.
+- **MUST NOT** nest the file under `docs/` or any other subdirectory; the mission is a top-level orientation point parallel to `spec/`, `tests/`, and the rest of the `project/` planning artefacts.
+- **MAY** be absent in repositories that haven't yet adopted the planning suite; absence is permitted by the sibling `project-structure` spec. Once present, every requirement in this spec applies.
+
+### Frontmatter schema
+
+- **MUST** open the file with a YAML frontmatter fence carrying the following fields, in this order:
+  - `mission_statement` (string, required, non-empty): the actual SMART-shaped sentence in the project's primary language; one sentence, no markdown formatting beyond inline punctuation.
+  - `relevant_outcomes` (list of outcome IDs, required, non-empty): every entry **MUST** match an `O-<n>` defined in `project/goals.md` per the sibling `roadmap` spec.
+  - `audiences` (list of audience identifiers, required, non-empty): every entry **MUST** match an audience entry in the project's audience artefact (`AUDIENCES.md` or the location declared by the consuming repo per `audience-identification`).
+  - `verifies_via` (string, required): pattern `<feature-id>:acceptance-<n>` (for example `F-3:acceptance-2`), naming the feature whose `verifies_sprint_value` frontmatter field points at the acceptance criterion that proves the mission is achieved; the named feature **MUST** exist under `project/features/` and the named acceptance identifier **MUST** exist on that feature.
+  - `time_bound` (object, required): one of two shapes, `{ kind: outcome, ref: O-<n> }` (Time-bound to a specific outcome from `goals.md`) or `{ kind: mvp_completion }` (Time-bound to the moment `mvp_status` reaches `achieved`); calendar-date forms are forbidden.
+  - `mvp_status` (enum, required): one of `defining` (the MVP scope is being shaped), `in_progress` (at least one MVP item is `active` or `done`), `achieved` (every MVP item is `done` and the verifying acceptance criterion is checked), `stabilised` (the achieved state has held across one full subsequent sprint per §Stabilisation gate).
+  - `created` (ISO date, required): the date the mission file was first written; never edited after creation.
+  - `revised_at` (ISO date or null, required): the date of the most recent meaningful revision (a change to the statement, the audiences, the verification, or the time-bound clause); null while the mission file is in its original-write state.
+- **MUST NOT** include calendar deadlines, OKR scores, KPI fields, or stakeholder-assignment fields beyond what's declared above; lints flag unknown keys.
+
+### Body sections
+
+- **MUST** carry the following level-2 sections in this order, even when content is sparse (skills depend on stable section headings):
+  - `## Statement`: the mission statement repeated as prose, immediately followed by a SMART decomposition (one short paragraph per letter, naming which frontmatter field anchors that letter—see §SMART contract).
+  - `## Audiences`: one paragraph per audience listed in the `audiences` frontmatter field, naming the audience and stating what the MVP delivers to that audience specifically; no audience may be listed in frontmatter without a paragraph here, and no paragraph may name an audience that isn't in the frontmatter list.
+  - `## Verification`: a short prose pointer to the feature and acceptance criterion named by `verifies_via`, repeating the criterion text verbatim so the mission file is readable without walking the feature corpus.
+  - `## Source`: the audit trail—which audience artefact was consulted (path plus its last-commit SHA at the time of writing), which `goals.md` outcomes were referenced, who or what authored the mission (operator name, skill version, or commit SHA of the mission-defining change).
+- **MAY** carry an additional `## Open questions` section for unresolved authoring decisions; **MUST NOT** alter the order of the four required sections to accommodate optional ones.
+
+### SMART contract
+
+The mission statement **MUST** satisfy each of the following five constraints, individually checkable from the artefacts named:
+
+- **Specific**: the `mission_statement` names both **what** the project does and **for whom**; the **for whom** **MUST** resolve to one or more entries in the `audiences` frontmatter list. A mission whose audience is implicit ("for users") fails this constraint; the audience identifier is explicit.
+- **Measurable**: the `verifies_via` frontmatter field names a single feature and a single acceptance criterion on that feature. When that acceptance criterion is checked (per the sibling `feature` spec), the mission is measurably achieved. No other verification mechanism is introduced.
+- **Achievable**: every roadmap item with `mvp: true` carries `detail: fine` and a non-null `target_sprint` per the sibling `roadmap` spec, and the count of MVP items **SHOULD** be roughly two-to-five sprints' worth of capacity. An unbounded MVP scope (every roadmap item flagged `mvp: true`) defeats achievability and **MUST** be rejected by consuming skills with a verbatim error.
+- **Relevant**: the `relevant_outcomes` frontmatter list is non-empty and every entry resolves to an outcome in `project/goals.md`. A mission that doesn't tie back to at least one declared outcome fails this constraint.
+- **Time-bound**: the `time_bound` frontmatter object is one of `{ kind: outcome, ref: O-<n> }` or `{ kind: mvp_completion }`. Calendar dates and free-text deadlines are rejected. The bound is intentionally outcome-shaped because hobby-scale sprint duration is variable per the sibling `sprint` spec; this spec inherits that constraint.
+
+### MVP definition and delimitation
+
+- **MUST** define the MVP as the set of roadmap items in `project/roadmap.md` whose YAML block carries `mvp: true`. The flag's authoritative location is the roadmap; the mission spec is the authority for the flag's semantics.
+- **MUST** treat any roadmap item with `mvp: false` as **post-MVP** and therefore optional for fulfilling the mission. Post-MVP items remain in the roadmap explicitly so the boundary between minimum and additional scope stays visible: naming an item but flagging it `mvp: false` is the canonical way to mark that the team knows about the item, that the item isn't part of MVP, and that the item waits.
+- **MUST** require, for every roadmap item with `mvp: true`, that at least one of its features (per the sibling `feature` spec) declares `verifies_sprint_value` non-null when that feature ships in the sprint that closes the MVP. Across the full MVP scope, exactly one feature **MUST** be the one named in the mission's `verifies_via` field; that feature is the **mission-verifying feature**.
+- **MUST NOT** allow a roadmap item to flip its `mvp` flag from `true` to `false` after the item has reached `status: active`; once an item enters MVP execution, removing it from MVP scope retroactively is forbidden because it would break the achievability bound the SMART contract relies on. Items **MAY** flip from `mvp: false` to `mvp: true` at any time before stabilisation.
+
+### Stabilisation gate
+
+- **MUST** treat the MVP as **stabilised** when, and only when, every condition below holds simultaneously:
+  - every roadmap item with `mvp: true` carries `status: done`;
+  - the sprint that closed the last MVP item is itself `status: closed` per the sibling `sprint` spec;
+  - one full subsequent sprint has reached `status: closed` (or `cancelled` due to no-fault-of-MVP reasons) without re-opening any MVP item to `status: active`;
+  - no defect-fix work targeting an MVP item is currently in `status: in_progress` per the sibling `feature` spec.
+- **MUST NOT** allow any post-MVP roadmap item (`mvp: false`) to transition `proposed → active` while `mvp_status` is any of `defining`, `in_progress`, or `achieved`. The transition is permitted only when `mvp_status: stabilised`.
+- **MUST** require the operator (or a future automation skill) to flip `mvp_status` to `stabilised` explicitly; the flip **MUST NOT** be inferred silently from satisfying the conditions above. The flip records the decision; the conditions justify it.
+- **MUST** revert `mvp_status: stabilised → in_progress` when an MVP item re-opens to `status: active` (for example because a defect surfaced after stabilisation); the gate then re-applies and post-MVP items already in `status: active` at the time of the revert **MAY** continue to completion but no new post-MVP item **MUST** be allowed to start until stabilisation is restored.
+- **MAY** record the stabilisation evidence (the sprint number that satisfied the one-full-subsequent-sprint condition, the date of the operator decision) in `## Source` for the audit trail.
+
+### Audience tailoring
+
+- **MUST** require, for every audience listed in `audiences`, a paragraph in `## Audiences` that names the audience identifier and states what the MVP delivers to that audience specifically. A bare list of audience names without per-audience paragraphs fails validation.
+- **MUST NOT** name an audience in `## Audiences` that isn't also in the `audiences` frontmatter list, and vice versa; the two surfaces are bidirectionally validated.
+- **SHOULD** keep each per-audience paragraph short (three to five sentences); when a single audience needs more, the audience itself is probably under-specified and `audience-identification` should be re-run rather than padding the mission file.
+- **MAY** group audiences when their MVP-deliverable is identical (one paragraph naming the two audiences and stating the shared deliverable), but each audience identifier **MUST** still appear by name and the grouping rationale **MUST** be stated in the same paragraph.
+
+### Cross-spec linkage
+
+- **MUST** treat `audience-identification` as the authority for the audience artefact's form and content. When the project has no audience artefact, mission authoring is blocked; the `audience-identify` skill **MUST** be dispatched first, identical to the rule that already applies to outcome authoring in the sibling `roadmap` spec.
+- **MUST** treat the sibling `roadmap` spec as the authority for the `mvp` field's location in the roadmap-item YAML schema; this spec is the authority for the field's semantics. The two surfaces refer to each other explicitly, and the cross-reference is one-way for each concern (location → roadmap, semantics → mission).
+- **MUST** treat the sibling `feature` spec as the authority for `verifies_sprint_value`; this spec consumes the mechanism and **MUST NOT** redefine it.
+- **MUST** treat `goals.md` (governed by `roadmap`) as the authority for outcome IDs; this spec only references them.
+
+### Hobby-scale variability
+
+- **MUST NOT** require effort estimates, calendar deadlines, velocity metrics, or stakeholder-sign-off fields on the mission file; the SMART contract above already substitutes for what those would catch in an enterprise context.
+- **SHOULD** tolerate long stretches between mission revision and MVP completion; an unchanged `mission_statement` is the correct state when the mission still describes what the project is doing.
+- **MAY** revise the mission statement at any time before `mvp_status: stabilised`; revisions after stabilisation **MUST** carry a one-paragraph rationale in `## Source` because they redefine what the stabilised MVP was for.
+
+## Acceptance Criteria
+
+- [ ] `project/mission.md` exists at the repo root of every adopting project; nested or alternative locations fail validation.
+- [ ] The mission frontmatter carries the eight required fields (`mission_statement`, `relevant_outcomes`, `audiences`, `verifies_via`, `time_bound`, `mvp_status`, `created`, `revised_at`) in the declared order; lints flag unknown keys and reject any calendar-date deadline field beyond `created` and `revised_at`.
+- [ ] The mission body carries the four required level-2 sections (`Statement`, `Audiences`, `Verification`, `Source`) in the declared order; missing sections fail validation.
+- [ ] Every audience in `audiences` resolves to an entry in the project's audience artefact and has a tailored paragraph in `## Audiences`; bare audience lists or orphaned paragraphs fail validation.
+- [ ] Every outcome in `relevant_outcomes` resolves to an `O-<n>` in `project/goals.md`; an empty list or an unresolved entry fails validation.
+- [ ] `verifies_via` resolves to a feature file under `project/features/` whose frontmatter declares `verifies_sprint_value` matching the named acceptance identifier; broken references fail validation.
+- [ ] `time_bound` is one of `{ kind: outcome, ref: O-<n> }` or `{ kind: mvp_completion }`; any other shape fails validation, and calendar-date forms are rejected with a verbatim error.
+- [ ] No post-MVP roadmap item (`mvp: false`) is in `status: active` while `mvp_status` is `defining`, `in_progress`, or `achieved`; the consuming skill rejects the transition with a verbatim error citing this spec.
+- [ ] Every roadmap item with `mvp: true` carries `detail: fine` and a non-null `target_sprint`; lints fail otherwise.
+- [ ] No roadmap item flips its `mvp` flag from `true` to `false` after entering `status: active`; the reverse direction (`false → true`) is permitted only before stabilisation.
+- [ ] `mvp_status` only transitions along the legal path `defining → in_progress → achieved → stabilised`, with the reverse `stabilised → in_progress` permitted when an MVP item re-opens; any other transition fails validation.
+- [ ] When `mvp_status: stabilised`, every roadmap item with `mvp: true` is in `status: done` and one full subsequent sprint has closed without re-opening any MVP item; the consuming skill verifies the conditions before accepting the operator's flip.
+- [ ] `audience-identification` is dispatched before mission authoring on a fresh repo with no audience artefact; missing audiences block mission writes the same way they block outcome writes per the sibling `roadmap` spec.
+- [ ] No mission revision after `mvp_status: stabilised` lacks a one-paragraph rationale in `## Source`; missing rationale fails validation.
+
+## Open Questions
+
+- Should the `verifies_via` field eventually allow multiple feature-plus-criterion pairs (a list rather than a single string), so that compound missions whose verification genuinely splits across two features remain expressible? Default: keep `verifies_via` a single `<feature-id>:acceptance-<n>` string (this repo's own `project/mission.md` ran a complete `defining → in_progress → achieved → stabilised` cycle on a single pair, so the single-pair default is validated, not merely hypothetical). Revisit when: an actual `project/mission.md` is authored whose MVP scope spans roadmap items that genuinely close in different sprints, so no single sprint can carry the one value-verifying feature, AND the operator can show the value can't collapse onto one acceptance criterion—concretely, a `mission-define` or `mission-revise` run is blocked because two distinct `verifies_sprint_value` features in two different closed sprints are both load-bearing for the same mission.
+- Should the stabilisation gate's "one full subsequent sprint" condition be tunable per project (some projects might want two)? Default: keep the fixed constant of one full subsequent sprint and add no `stabilisation_soak_sprints` field (this repo's Sprint 0002 satisfied the soak for the MVP closed in Sprint 0001 with no regression, so the default has positive usage data behind it). Revisit when: a real `project/mission.md` shows a post-stabilisation regression that a single subsequent soak sprint demonstrably failed to catch—an MVP item re-opening to `status: active` in the second post-MVP sprint after `stabilised` was flipped—establishing that one sprint was too short for that project.
+- Should `mvp_status: stabilised → in_progress` reversion automatically halt every post-MVP item already in `status: active`, or only block new starts? Default: keep the softer rule at §Stabilisation gate—a revert blocks new post-MVP starts but lets in-flight post-MVP items finish, with no automation to forcibly halt active items. Revisit when: a real post-stabilisation revert occurs (`stabilised → in_progress` recorded in some `project/mission.md` §Source) AND a defect post-mortem shows that letting an in-flight post-MVP item run to completion during the revert masked or amplified the regression. No revert has been observed in the portfolio so far.
+- Should the spec eventually carry a machine-readable mission-coverage report (which audiences the MVP serves, with verification status per audience)? Default: continue to defer the report, and build it as a generated artefact rather than authored frontmatter when it lands (the "at least one project has run a full mission cycle" condition is already met, so the deferral rests solely on the missing downstream consumer). Revisit when: a named downstream consumer requires per-audience MVP-verification status keyed off the mission rather than the release audience artefact—concretely, when `release-skill-layer` Skill A's `## Audiences served` subsection or a future `audience-doc-author` step is changed to read `project/mission.md`'s `## Audiences` and `verifies_via` for per-audience verification status. Today no spec consumes the mission for coverage; `release-skill-layer` maps audiences from the release audience artefact, not the mission.


### PR DESCRIPTION
## Summary

Author the project's first `project/mission.md` by running the roadmap → feature → mission planning cascade, closing the missing-mission gap (portfolio audit W1, `nolte/claude-shared#263`) that left the rendered portfolio inventory showing the missing-mission placeholder.

## Changes

- Add roadmap item `R-1` "One-shot provisioning reaches a complete developer environment" (`outcomes: [O-1]`, `detail: fine`, `target_sprint: null`, `mvp: false`).
- Decompose `R-1` into feature `F-1` (`project/features/clean-machine-provisioning.md`) carrying `verifies_sprint_value: acceptance-5`, consistency findings recorded inline.
- Author `project/mission.md` (`mvp_status: defining`, `verifies_via: F-1:acceptance-5`, `time_bound: {outcome, O-1}`).
- Vendor the governance specs the planning skills require locally: `spec/project/{feature,mission,audience-identification}/{en,de}.md`, verbatim from `nolte/claude-shared`, and regenerate `spec/README.md`.
- Bundle the pre-existing untracked spec scaffolding (`spec/containerised-provisioning-tests/`, `spec/.spec-config.yml`) so the spec tree and F-1's test-hook references resolve.

## Linked issues

Closes #80
Refs spec/containerised-provisioning-tests/
Refs spec/project/audience-identification/
Refs spec/project/feature/
Refs spec/project/mission/

## Testing

- `task lint` (pre-commit: check-yaml, end-of-file-fixer, trailing-whitespace) — Passed on all files.
- F-1 consistency check via `feature-consistency-reviewer` agent — prior-art + clean, both `proceed` (no `draft → ready` blocker).
- `task test` (Vale) is local-only / non-gating — see Risk notes.

## Risk / rollout notes

- **Issue #80 — classification `feature-request`** (primary; establishes the project's mission / MVP-planning foundation), **`docs`** (secondary; planning artefacts). Route-to-pipeline issue that prescribed the cascade itself.
- **Per-work-package audit trail:**
  - P1 roadmap item `R-1` → skill `nolte-shared:roadmap-plan`
  - P2 feature `F-1` → skill `nolte-shared:feature-decompose` + agent `nolte-shared:feature-consistency-reviewer`
  - Prerequisite audience artefact → skill `nolte-shared:audience-identify` (validate; `AUDIENCES.md` already valid, no change)
  - P3 `project/mission.md` → skill `nolte-shared:mission-define`
  - Prerequisite spec vendoring → no matching specialised agent — generalist remediation (the `spec` skill authors new specs, it does not import canonical ones)
  - `mvp: false` backfill on `R-1` → no matching specialised agent — generalist remediation (single-field schema-consistency edit)
- **Deviations from the issue's proposed values:** `target_sprint: null` instead of `1` (no `project/sprints/` yet); `mvp_status: defining` chosen over a full `sprint-plan` sub-cascade — `R-1` is not yet flagged `mvp: true` or scheduled, so the Achievable bound holds vacuously. Follow-up: schedule `R-1` (`sprint-plan`), flip `mvp: true` + `mvp_status: defining → in_progress` when MVP work starts.
- **Vale:** `task test` reports ~4.5k errors, almost entirely German spelling in the vendored `de.md` translations (English dictionary) plus technical terms in the en specs. Vale is not in CI and not a pre-commit hook — local, non-gating, and a pre-existing pattern (the bundled `containerised-provisioning-tests/de.md` already trips it). Follow-up: Vale German-prose handling / skip `**/de.md`. Not a blocker.
- **P4 out of scope here:** re-rendering the portfolio inventory runs in `nolte/claude-shared` after this lands.
- Planning/spec docs only — no runtime code, dependencies, or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)