### PR TITLE
feat(spec): add containerised provisioning tests specification

### DIFF
--- a/spec/.spec-config.yml
+++ b/spec/.spec-config.yml
@@ -1,0 +1,3 @@
+canonical_language: en
+languages: [en, de]
+spec_root: spec

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,5 @@
+# Specifications
+
+| Slug | Title (en) | Title (de) | Status | Last updated |
+| --- | --- | --- | --- | --- |
+| [containerised-provisioning-tests](containerised-provisioning-tests/en.md) | Containerised Provisioning Tests | Containerisierte Provisionierungstests | draft | unversioned |

--- a/spec/containerised-provisioning-tests/de.md
+++ b/spec/containerised-provisioning-tests/de.md
@@ -1,0 +1,102 @@
+# Containerisierte Provisionierungstests
+
+Status: draft
+
+## Kontext
+
+Dieses Repository ist ein [chezmoi](https://www.chezmoi.io/)-Quellbaum, der Entwickler-Workstations provisioniert. Das eigentliche „Build-Artefakt" ist der Zustand, den `chezmoi init --apply https://github.com/nolte/workstation.git` auf einer Zielmaschine herstellt: eine befüllte `~/.tool-versions` mit asdf-verwalteten CLIs, getemplatete Dotfiles (`~/.gitconfig`, `~/taskfile.yaml`), zwei Python-Virtualenvs unter `~/.venvs/`, drei zsh-Plugins unter `~/.oh-my-zsh/custom/plugins/` und ein Checkout der geteilten Taskfile-Collection unter `~/.local/share/taskfile-collection/`.
+
+Die bestehende CI-Pipeline (`.github/workflows/build-static-tests.yaml`) deckt Prosa-Linting (Vale), pre-commit, Trivy und chain-bench ab. Keiner dieser Jobs übt den eigentlichen Provisionierungspfad aus — sie validieren die *Quellen*, nicht das *Ergebnis*. Dadurch können heute drei Klassen von Regressionen unbemerkt auf `develop` landen:
+
+- Eine in `chezmoi_config/dot_tool-versions` gebumpte Tool-Version hat kein funktionierendes asdf-Plugin oder kein passendes Release-Artefakt mehr.
+- Eine Änderung an einem der `run_onchange_*`-Skripte bricht die Installation auf einer frischen Maschine, obwohl die gerenderte Datei `check-yaml` noch besteht.
+- Eine Änderung an `.chezmoiexternal.toml` referenziert ein umgezogenes oder umbenanntes Upstream-Repo und bricht damit Neu-Bootstraps, ohne Maschinen zu beeinflussen, die das External bereits gecached haben.
+
+Da der einzig sichere Ort, das durchgehend zu üben, eine Wegwerf-Umgebung ist, MUSS der Testpfad in einem Container leben. Der Container ist die Grenze, die das `$HOME` der Entwickler-Maschine und das User-FS des GitHub-Runners davor schützt, von einem ausschließlich als Test gedachten chezmoi-Lauf verändert zu werden.
+
+## Ziele
+
+- Verifizieren, dass `chezmoi apply` gegen den Inhalt dieses Repos auf einer sauberen Linux-Umgebung den erwarteten On-Disk-Zustand erzeugt — nicht nur, dass die Templates rendern.
+- Die Verifikation automatisch laufen lassen bei jeder Änderung, die den Provisionierungspfad plausibel beeinflussen kann (push/PR auf `develop`, push auf `main`).
+- Upstream-Drift (asdf-Plugins, Release-Artefakte, externe Repos) in fester wöchentlicher Kadenz erkennen, ohne dass Code-Änderungen nötig sind.
+- Der Entwicklerin dieselbe Verifikation lokal über einen einzigen `task`-Aufruf bereitstellen, ohne zusätzliche Einrichtung jenseits einer vorhandenen Docker-Installation.
+- Alle Nebenwirkungen eines Testlaufs innerhalb des Containers halten; nichts auf Host oder Runner wird verändert.
+- Idempotenz nachweisen: Ein zweites `chezmoi apply` auf einem bereits provisionierten Stand MUSS ein No-Op sein.
+
+## Nicht-Ziele
+
+- Verifikation der macOS-Provisionierung. Das Repo ist heute Linux-fokussiert; ein macOS-Pfad bräuchte eine eigene Spec und einen Nicht-Container-Runner.
+- Performance-, Durchsatz- oder Wall-Clock-Benchmarks des Apply-Vorgangs.
+- Verifikation der *Inhalte* der `nolte/taskfiles`-Collection, die `.chezmoiexternal.toml` klont. Dieses Repo besitzt seine eigenen Tests.
+- Verifikation der Workflows `release-cd-deliver-docs.yml` oder `release-cd-refresh-master.yml`. Die betreffen Doc-Auslieferung und Release-Fast-Forward, nicht die Provisionierung.
+- Konkrete Dockerfile-Inhalte, exakte Shell-Skripte oder Assertion-Tool-Entscheidungen vorzuschreiben. Diese Spec definiert das *Was* und die *Randbedingungen*; der Implementierungs-PR macht das konkret.
+- `build-static-tests.yaml` ersetzen. Die neue Pipeline ist additiv — pre-commit, Vale, Trivy und chain-bench bleiben eigene Jobs.
+
+## Anforderungen
+
+- **MUSS [MUST]**
+  - Die gesamte Testausführung MUSS in einem Container stattfinden, der aus einem in dieses Repo eingecheckten `Dockerfile` gebaut wird (Vorschlagspfad: `tests/Dockerfile`). Das Base-Image MUSS ein gepinntes Ubuntu-LTS-Tag (oder ein Digest) sein, und der Pin MUSS für Renovate erkennbar sein, damit er zusammen mit dem übrigen Toolchain-Stand gebumpt wird.
+  - Der Container MUSS ausschließlich die minimal nötigen System-Voraussetzungen installieren, um `chezmoi`, `asdf` und `python` lauffähig zu machen. Jedes weitere in `chezmoi_config/dot_tool-versions` gelistete Tool MUSS *vom Provisionierungslauf selbst* installiert werden, nicht ins Image vorgebacken — sonst übte der Test gerade den Pfad nicht aus, den er zu prüfen vorgibt.
+  - Der Test-Entrypoint MUSS `chezmoi init` gegen den lokalen Working-Tree dieses Repos ausführen (nicht gegen einen Remote-Clone von GitHub), damit die Änderungen eines PR getestet werden, bevor sie auf `develop` existieren.
+  - Der Test-Entrypoint MUSS `chezmoi apply` einmal ausführen, die Nachbedingungen aus §„Provisionierungs-Nachbedingungen" prüfen, anschließend `chezmoi apply` ein *zweites* Mal ausführen und sichern, dass kein `run_onchange_*`-Skript erneut feuert und der Exit-Status null ist.
+  - Die vom Container konsumierte `chezmoi.toml` MUSS eine Testfixture unter `tests/` mit Dummy-Werten für `git_email` und `git_name` sein. Der Container DARF die `~/.config/chezmoi/chezmoi.toml` von Host oder Runner NICHT lesen.
+  - Der Container MUSS ohne `--privileged`, ohne Mount des Docker-Sockets und ohne Bind-Mount des Entwickler-`$HOME` oder irgendeines anderen User-Verzeichnisses außerhalb des Repo-Checkouts laufen. Das Repo-Checkout selbst KANN [MAY] read-only gemountet oder zur Build-Zeit per `COPY` ins Image gelegt werden, aber das `$HOME` im Container MUSS ein im Image frisch angelegtes Verzeichnis sein.
+  - Die neue Pipeline MUSS unter `.github/workflows/` angesiedelt sein und auf push auf `develop`, push auf `main`, Pull Requests gegen `develop` sowie auf einem wöchentlichen Schedule entsprechend dem bestehenden Static-Tests-Cron (`cron: '16 0 * * 1'`) laufen.
+  - Die Root-`Taskfile.yml` MUSS ein neues Target `test:container` bekommen, das *dasselbe* Image mit *demselben* Entrypoint baut und startet wie der Workflow. Lokale und CI-Läufe MÜSSEN sich diesen einen Code-Pfad teilen; eine Regression in einem MUSS sich ohne Anpassungen im anderen reproduzieren lassen.
+  - Der Platzhalter `tests/.gitkeep` MUSS in demselben PR entfernt werden, der die echten Testartefakte unter `tests/` einführt.
+  - Die Assertion-Schicht MUSS in [Bats](https://github.com/bats-core/bats-core) geschrieben sein. Jede `MUSS`-Nachbedingung aus §„Provisionierungs-Nachbedingungen" MUSS einem eigenen `@test`-Block entsprechen, damit Fehler einzeln pro Assertion gemeldet werden und nicht als ein einziger Shell-Exit. Die Bats-Version MUSS im Repo in einer für Renovate erkennbaren Form gepinnt sein (entweder als asdf-verwaltetes Plugin, das nur im Test-Image verwendet wird, oder als Distro-Paketversions-Pin im Dockerfile), damit die Test-Engine-Version im Gleichschritt mit der übrigen Toolchain gebumpt wird.
+  - Fehlerklassen MÜSSEN unterscheidbar sein. Ein fehlgeschlagener `@test`-Block (Assertion: `asdf which kubectl` löst nicht auf, `~/.venvs/docs` fehlt) erscheint als Bats-Test-Fehlschlag mit einem Gesamt-Exit ungleich null und Per-Test-Diagnose; ein fehlgeschlagener Image-Build, ein Netzwerkfehler beim Ziehen eines asdf-Plugins oder ein chezmoi-Crash im Entrypoint MUSS separat sichtbar werden (z. B. über einen anderen Exit-Code, eine andere Workflow-Step-Grenze oder einen klar markierten Log-Marker), damit eine rote Pipeline sofort sagt, welche Fehlerklasse zu triagieren ist.
+
+- **SOLLTE [SHOULD]**
+  - Das Dockerfile SOLLTE unter `tests/` neben Fixtures und Entrypoint-Skript liegen, damit die gesamte Testfläche ein Ordner ist.
+  - Der Base-Image-Pin SOLLTE ein Digest sein, kein floatendes Tag, damit ein Upstream-Image-Rebuild nicht stillschweigend das Verhalten zwischen zwei Läufen desselben Commits ändert.
+  - Die Pipeline SOLLTE die TAP-Ausgabe von Bats (oder das äquivalente Bats-native Pretty-Format) ins CI-Log schreiben und den TAP-Stream als Workflow-Artefakt hochladen, damit ein Fehler allein aus dem CI heraus debuggbar ist — jeder `@test` und die jeweils inspizierten Artefakte (Tool-Liste, Dotfile-Liste, Venv-Inhaltsstichprobe) tauchen namentlich im Log auf, ohne dass lokal nachgestellt werden muss.
+  - Jede `MUSS`-Assertion aus §„Provisionierungs-Nachbedingungen" SOLLTE unabhängig geübt werden, damit ein einzelner Fehlschlag den Rest nicht maskiert.
+  - Der Container SOLLTE auf `linux/amd64` laufen. Weitere Architekturen KÖNNEN [MAY] später ergänzt werden, sind aber von dieser Spec nicht gefordert.
+  - Der wöchentliche Cron-Lauf SOLLTE sein Ergebnis über denselben Benachrichtigungspfad melden wie andere scheduled Jobs in diesem Repo (keine Sonderfall-Alarmierung).
+
+- **KANN [MAY]**
+  - Die Pipeline KANN Container-Image-Layer im GitHub-Actions-Cache zwischenspeichern, sofern der Cache-Key den Dockerfile-Hash mit einschließt, damit eine Dockerfile-Änderung einen Rebuild erzwingt.
+  - Die Pipeline KANN einen Smoke-Schritt enthalten, der nach dem Apply ein repräsentatives `task` aus `~/taskfile.yaml` ausführt, um zu verifizieren, dass das getemplatete Taskfile seine Includes gegen `~/.local/share/taskfile-collection/` auflöst.
+  - Folge-PRs KÖNNEN die Spec um eine Distro-Matrix erweitern (z. B. Ubuntu LTS + Fedora) — außerhalb des Scopes hier, aber die Implementierung SOLLTE eine Matrix-Erweiterung nicht schwerer machen als ein Tausch des Base-Images.
+
+## Provisionierungs-Nachbedingungen
+
+Der folgende On-Disk-Zustand im Container ist das, was ein grüner Lauf assertet. Der Implementierungs-PR übersetzt das in konkrete Checks; die Spec fixiert den Vertrag.
+
+- Für jedes in `chezmoi_config/dot_tool-versions` gelistete Tool MUSS `asdf which <tool>` einen existierenden, ausführbaren Pfad auflösen. Die Tool-Liste der Assertions wird aus der Datei gelesen, nicht im Test hartkodiert — Drift in `dot_tool-versions` darf keine Parallelpflege der Assertions erfordern.
+- `~/.gitconfig` MUSS existieren und MUSS die Dummy-Werte `git_email` / `git_name` aus der Test-`chezmoi.toml`-Fixture enthalten (damit nachgewiesen ist, dass die Template-Substitution wirklich lief).
+- `~/.tool-versions` MUSS existieren und MUSS byteidentisch zu `chezmoi_config/dot_tool-versions` sein.
+- `~/taskfile.yaml` MUSS existieren und MUSS `~/.local/share/taskfile-collection/` irgendwo in seinem Include-Graphen referenzieren.
+- `~/.venvs/development/` und `~/.venvs/docs/` MÜSSEN als gültige Python-Virtualenvs existieren. Jedes MUSS mindestens ein Stichproben-Paket aus dem zugehörigen `requirements-*.txt` enthalten: `pre-commit` für development, `mkdocs-material` für docs.
+- Die drei in `.chezmoiexternal.toml` deklarierten zsh-Plugin-Verzeichnisse MÜSSEN als nicht-leere Git-Checkouts unter `~/.oh-my-zsh/custom/plugins/` existieren.
+- `~/.local/share/taskfile-collection/` MUSS als nicht-leerer Git-Checkout existieren.
+- Jedes `run_onchange_*`-Skript in `chezmoi_config/` MUSS beim ersten Apply einen beobachtbaren Seiteneffekt hinterlassen haben (asdf-Plugins ergänzt, `asdf install` ausgeführt, Venvs angelegt). Das zweite Apply DARF sie NICHT erneut ausführen; der Test prüft das über die `chezmoi apply --verbose`-Ausgabe oder ein äquivalentes chezmoi-natives Signal.
+
+## Verhältnis zu bestehenden Repo-Konventionen
+
+- `CLAUDE.md` nennt zwei strukturelle Tatsachen, die diese Spec übernimmt, ohne sie zu wiederholen: die `.chezmoiroot = chezmoi_config`-Indirektion und die bewusste Duplizierung von `requirements-development.txt` / `requirements-mkdocs.txt` zwischen `docs/` (vom Docs-Delivery-Workflow genutzt) und `chezmoi_config/` (zur Apply-Zeit genutzt). Der Test MUSS die `chezmoi_config/`-Kopien konsumieren, da das die Dateien sind, die `chezmoi apply` tatsächlich installiert.
+- Alle `.github/workflows/`-Dateien in diesem Repo sind dünne Wrapper über `nolte/gh-plumbing`-Reusable-Workflows, an unveränderliche Release-Tags gepinnt und gemeinsam von Renovate gebumpt. Der neue Provisionierungs-Test-Workflow SOLLTE diesem Muster folgen *nur falls* es upstream einen passenden Reusable Workflow gibt; andernfalls KANN er ein in sich geschlossener Workflow sein, mit der expliziten Anerkennung, dass er damit der erste Non-Reusable-Workflow in diesem Repo ist.
+
+## Akzeptanzkriterien
+
+- [ ] `tests/` enthält ein `Dockerfile`, eine Test-`chezmoi.toml`-Fixture und ein Entrypoint-Skript. `tests/.gitkeep` ist entfernt.
+- [ ] Ein neuer Workflow unter `.github/workflows/` startet den Container auf push/PR auf `develop`, push auf `main` und auf dem Cron-Schedule `16 0 * * 1`.
+- [ ] Die Root-`Taskfile.yml` stellt `task test:container` bereit, das dasselbe Image und denselben Entrypoint baut und startet wie der Workflow.
+- [ ] Ein sauberer lokaler Aufruf von `task test:container` endet auf dem aktuellen `develop`-Tip mit Exit-Code 0.
+- [ ] Während eines grünen Laufs ist `asdf which <tool>` für jedes in `chezmoi_config/dot_tool-versions` gelistete Tool erfolgreich.
+- [ ] Während eines grünen Laufs existieren `~/.gitconfig`, `~/.tool-versions` und `~/taskfile.yaml`; `~/.gitconfig` enthält die Dummy-Fixture-Werte; `~/.tool-versions` ist byteidentisch zu `chezmoi_config/dot_tool-versions`.
+- [ ] Während eines grünen Laufs enthält `~/.venvs/development/` `pre-commit` und `~/.venvs/docs/` `mkdocs-material`.
+- [ ] Während eines grünen Laufs existieren die drei zsh-Plugin-Verzeichnisse unter `~/.oh-my-zsh/custom/plugins/` und `~/.local/share/taskfile-collection/` als nicht-leere Git-Checkouts.
+- [ ] Die Assertion-Suite liegt unter `tests/*.bats`, jeder `MUSS`-Eintrag aus §„Provisionierungs-Nachbedingungen" mappt auf genau einen `@test`-Block, und ein einzelner fehlgeschlagener `@test` überspringt die übrigen Assertions nicht.
+- [ ] Ein zweites direkt nachfolgendes `chezmoi apply` endet mit Exit-Code 0 und löst keine erneute Ausführung der `run_onchange_*`-Skripte aus.
+- [ ] Der Container-Lauf bindet kein Host-`$HOME` ein, verlangt kein `--privileged` und mountet keinen Docker-Socket.
+- [ ] `build-static-tests.yaml` läuft weiterhin unverändert auf denselben Triggern; nichts in der neuen Pipeline ersetzt oder kurzschließt deren Jobs.
+- [ ] Eine bewusst kaputtmachende Änderung an `chezmoi_config/dot_tool-versions` (z. B. eine nicht existierende Tool-Version) lässt die neue Pipeline fehlschlagen; das Zurücknehmen der Änderung macht sie wieder grün.
+- [ ] Der Base-Image-Pin und der Bats-Versions-Pin tauchen beide im Renovate-Dashboard auf, und Update-PRs für beide lassen sich von Renovate ohne manuelle Konfig-Eingriffe öffnen.
+
+## Offene Fragen
+
+- Soll das Image gebaut und nach GHCR gepusht werden, damit der Cron-Job und der Per-PR-Job es teilen können, oder in jedem Job neu gebaut? Trade-off ist Registry-Pflege gegen Build-Zeit.
+- Ist beim zweiten Apply das Parsen von `chezmoi apply --verbose` zuverlässig genug, um die erneute Ausführung von `run_onchange_*`-Skripten zu erkennen, oder brauchen wir ein chezmoi-natives Signal (z. B. Vergleich von State-Hashes)? Das beeinflusst, ob der Test von einem CLI-Ausgabeformat abhängt, das sich zwischen chezmoi-Releases ändern kann.
+- Reicht eine Single-Distro-Baseline (Ubuntu LTS) für den Anfang, oder sollte die erste Iteration bereits eine zweite Distro enthalten, um Ubuntu-spezifische Drift zu verhindern? Aktuelle Entscheidung: erst Single-Distro, Matrix später — nach den ersten drei Monaten grüner Läufe neu bewerten.

--- a/spec/containerised-provisioning-tests/en.md
+++ b/spec/containerised-provisioning-tests/en.md
@@ -1,0 +1,102 @@
+# Containerised Provisioning Tests
+
+Status: draft
+
+## Context
+
+This repository is a [chezmoi](https://www.chezmoi.io/) source tree that provisions developer workstations. Its real "build artefact" is the state produced on a target machine by `chezmoi init --apply https://github.com/nolte/workstation.git`: a populated `~/.tool-versions` with asdf-managed CLIs, templated dotfiles (`~/.gitconfig`, `~/taskfile.yaml`), two Python virtualenvs under `~/.venvs/`, three zsh plugins under `~/.oh-my-zsh/custom/plugins/`, and a checkout of the shared taskfile collection under `~/.local/share/taskfile-collection/`.
+
+The existing CI pipeline (`.github/workflows/build-static-tests.yaml`) covers prose linting (Vale), pre-commit, Trivy, and chain-bench. None of these exercise the actual provisioning path — they validate the *sources*, not the *result*. As a consequence, three classes of regression can land unnoticed on `develop` today:
+
+- A bumped tool version in `chezmoi_config/dot_tool-versions` no longer has a working asdf plugin or release artefact.
+- A change to one of the `run_onchange_*` scripts breaks installation on a clean machine, even though the rendered file still passes `check-yaml`.
+- A change to `.chezmoiexternal.toml` references a moved or renamed upstream repo, breaking new-machine bootstraps without affecting machines that already have the external cached.
+
+Because the only safe place to exercise this end-to-end is a throwaway environment, the test path must live inside a container. The container is the boundary that protects the developer's host `$HOME` and the GitHub-hosted runner's user FS from being mutated by a chezmoi run intended only as a test.
+
+## Goals
+
+- Verify that `chezmoi apply` against the contents of this repo produces the expected on-disk state on a clean Linux environment — not just that the templates render.
+- Make the verification automatic on every change that can plausibly affect the provisioning path (push/PR to `develop`, push to `main`).
+- Catch upstream drift (asdf plugins, release artefacts, external repos) on a fixed weekly cadence without code changes.
+- Give a developer the exact same verification locally via a single `task` invocation, with no extra setup beyond having Docker.
+- Keep all side effects of a test run inside the container; nothing on the host or runner is mutated.
+- Assert idempotency: a second `chezmoi apply` on an already-provisioned state must be a no-op.
+
+## Non-Goals
+
+- macOS provisioning verification. The repo is Linux-focused today; a macOS path would need a separate spec and a non-container runner.
+- Performance, throughput, or wall-clock benchmarks of the apply process.
+- Verifying the *contents* of the `nolte/taskfiles` collection that `.chezmoiexternal.toml` clones. That repo owns its own tests.
+- Verifying the `release-cd-deliver-docs.yml` or `release-cd-refresh-master.yml` workflows. Those concern documentation delivery and release fast-forwarding, not provisioning.
+- Prescribing concrete Dockerfile contents, exact shell scripts, or assertion-tool choices. This spec defines *what* must be verified and *under which constraints*; the implementation PR makes those concrete.
+- Replacing `build-static-tests.yaml`. The new pipeline is additive — pre-commit, Vale, Trivy, and chain-bench remain their own jobs.
+
+## Requirements
+
+- **MUST**
+  - All test execution MUST happen inside a container built from a `Dockerfile` checked into this repo (proposed path: `tests/Dockerfile`). The base image MUST be a pinned Ubuntu LTS tag (or a digest), and the pin MUST be discoverable by Renovate so it is bumped together with the rest of the toolchain.
+  - The container MUST install only the minimal system prerequisites needed to run `chezmoi`, `asdf`, and `python`. Every other tool listed in `chezmoi_config/dot_tool-versions` MUST be installed *by the provisioning run itself*, not pre-baked into the image — otherwise the test would not exercise the path it claims to cover.
+  - The test entrypoint MUST run `chezmoi init` against the local working tree of this repo (not a remote clone of GitHub) so a PR's changes are tested before they exist on `develop`.
+  - The test entrypoint MUST run `chezmoi apply` a first time, assert the post-conditions in §"Provisioning post-conditions", then run `chezmoi apply` a *second* time and assert that no `run_onchange_*` script fired again and that exit status is zero.
+  - The `chezmoi.toml` consumed by the container MUST be a test fixture stored under `tests/` with dummy values for `git_email` and `git_name`. The container MUST NOT read `~/.config/chezmoi/chezmoi.toml` from the host or runner.
+  - The container MUST run without `--privileged`, without mounting the Docker socket, and without bind-mounting the developer's `$HOME` or any user-owned directory outside the repo checkout. The repo checkout itself MAY be mounted read-only or `COPY`'d in at build time, but the container's `$HOME` MUST be a fresh directory created inside the image.
+  - The new pipeline MUST be wired into `.github/workflows/` so it runs on push to `develop`, push to `main`, pull requests targeting `develop`, and a weekly schedule matching the existing static-tests cron (`cron: '16 0 * * 1'`).
+  - The root `Taskfile.yml` MUST gain a `test:container` target that builds and runs the *same* image with the *same* entrypoint as the workflow uses. Local and CI runs MUST share that single code path; a regression in one MUST be reproducible in the other without changes.
+  - The placeholder `tests/.gitkeep` MUST be removed in the same PR that introduces real test artefacts under `tests/`.
+  - The assertion layer MUST be written in [Bats](https://github.com/bats-core/bats-core). Each `MUST`-level post-condition in §"Provisioning post-conditions" MUST correspond to its own `@test` block, so failures are reported one-per-assertion rather than as a single shell exit. The Bats version MUST be pinned in the repo in a Renovate-discoverable form (either as an asdf-managed plugin used only inside the test image, or as a distro-package version pin in the Dockerfile), so the test-engine version is bumped in lockstep with the rest of the toolchain.
+  - Test failure modes MUST be distinguishable from infrastructure failure. A failed `@test` block (assertion: `asdf which kubectl` doesn't resolve, `~/.venvs/docs` missing) surfaces as a Bats test failure with a non-zero overall exit and per-test diagnostics; a failed image build, a network error pulling an asdf plugin, or a chezmoi crash inside the entrypoint MUST surface separately (e.g. via a distinct exit code, a distinct workflow step boundary, or a clearly tagged log marker) so a red pipeline immediately tells the operator which failure class to triage.
+
+- **SHOULD**
+  - The Dockerfile SHOULD live under `tests/` alongside the fixtures and entrypoint script so the whole test surface is one folder.
+  - The base image pin SHOULD be a digest, not a floating tag, so an upstream image rebuild cannot silently change behaviour between two runs of the same commit.
+  - The pipeline SHOULD emit Bats' TAP output (or the equivalent Bats-native pretty format) into the CI log and SHOULD upload the TAP stream as a workflow artefact, so a failure is debuggable from CI alone — every `@test` and the artefacts it inspected (tool list, dotfile list, venv contents sample) appear by name in the log without rerunning locally.
+  - Each `MUST`-level assertion in §"Provisioning post-conditions" SHOULD be exercised independently so a single failure does not mask the rest.
+  - The container SHOULD be runnable on `linux/amd64`. Additional architectures MAY be added later but are not required by this spec.
+  - The weekly cron run SHOULD post its result through the same notification path as other scheduled jobs in this repo (no special-case alerting).
+
+- **MAY**
+  - The pipeline MAY cache the container image layers in the GitHub Actions cache, provided the cache key incorporates the Dockerfile hash so a Dockerfile change forces a rebuild.
+  - The pipeline MAY include a smoke step that runs a representative `task` from `~/taskfile.yaml` after apply, to verify that the templated Taskfile resolves its includes against `~/.local/share/taskfile-collection/`.
+  - Future PRs MAY extend the spec with a distro matrix (e.g. Ubuntu LTS + Fedora) — out of scope here, but the implementation SHOULD NOT make a matrix harder than swapping the base image.
+
+## Provisioning post-conditions
+
+The following on-disk state inside the container is what a successful run asserts. The implementation PR turns this into concrete checks; the spec fixes the contract.
+
+- For every tool listed in `chezmoi_config/dot_tool-versions`, `asdf which <tool>` MUST resolve to a path that exists and is executable. The list of tools to assert is read from the file, not hard-coded in the test — drift in `dot_tool-versions` must not require a parallel update of the assertions.
+- `~/.gitconfig` MUST exist and MUST contain the dummy `git_email` / `git_name` values from the test `chezmoi.toml` fixture (proving template substitution actually ran).
+- `~/.tool-versions` MUST exist and MUST match the bytes of `chezmoi_config/dot_tool-versions`.
+- `~/taskfile.yaml` MUST exist and MUST reference `~/.local/share/taskfile-collection/` somewhere in its include graph.
+- `~/.venvs/development/` and `~/.venvs/docs/` MUST exist as valid Python virtualenvs. Each MUST contain at least one sample package from its respective `requirements-*.txt`: `pre-commit` for development, `mkdocs-material` for docs.
+- The three external zsh plugin directories declared in `.chezmoiexternal.toml` MUST exist as non-empty git checkouts under `~/.oh-my-zsh/custom/plugins/`.
+- `~/.local/share/taskfile-collection/` MUST exist as a non-empty git checkout.
+- Each `run_onchange_*` script in `chezmoi_config/` MUST have left an observable side effect on the first apply (asdf plugins added, asdf install completed, venvs created). The second apply MUST NOT re-run them, which the test verifies via the `chezmoi apply --verbose` output or an equivalent chezmoi-native signal.
+
+## Relationship to existing repository conventions
+
+- `CLAUDE.md` calls out two structural facts that this spec inherits without restating them: the `.chezmoiroot = chezmoi_config` indirection, and the deliberate duplication of `requirements-development.txt` / `requirements-mkdocs.txt` between `docs/` (used by the docs-delivery workflow) and `chezmoi_config/` (used at apply time). The test MUST consume the `chezmoi_config/` copies, since those are what `chezmoi apply` actually installs.
+- All `.github/workflows/` files in this repo are thin wrappers over `nolte/gh-plumbing` reusable workflows, pinned to immutable release tags and bumped by Renovate together. The new provisioning-test workflow SHOULD follow the same pattern *only if* a suitable reusable workflow exists upstream; otherwise it MAY be a self-contained workflow, with the explicit acknowledgement that it is the first non-reusable workflow in this repo.
+
+## Acceptance Criteria
+
+- [ ] `tests/` contains a `Dockerfile`, a test `chezmoi.toml` fixture, and an entrypoint script. `tests/.gitkeep` is removed.
+- [ ] A new workflow under `.github/workflows/` runs the container on push/PR to `develop`, push to `main`, and the cron schedule `16 0 * * 1`.
+- [ ] The root `Taskfile.yml` exposes `task test:container`, which builds and runs the same image and entrypoint as the workflow.
+- [ ] A clean local invocation of `task test:container` exits 0 on the current `develop` tip.
+- [ ] During a green run, `asdf which <tool>` succeeds for every tool listed in `chezmoi_config/dot_tool-versions`.
+- [ ] During a green run, `~/.gitconfig`, `~/.tool-versions`, and `~/taskfile.yaml` exist; `~/.gitconfig` contains the dummy fixture values; `~/.tool-versions` is byte-identical to `chezmoi_config/dot_tool-versions`.
+- [ ] During a green run, `~/.venvs/development/` contains `pre-commit` and `~/.venvs/docs/` contains `mkdocs-material`.
+- [ ] During a green run, the three zsh plugin directories under `~/.oh-my-zsh/custom/plugins/` and `~/.local/share/taskfile-collection/` exist as non-empty git checkouts.
+- [ ] The assertion suite lives under `tests/*.bats`, every `MUST`-level entry in §"Provisioning post-conditions" maps to exactly one `@test` block, and a single failing `@test` does not skip the remaining assertions.
+- [ ] A second consecutive `chezmoi apply` exits 0 and triggers no `run_onchange_*` re-execution.
+- [ ] The container run does not bind-mount the host `$HOME`, does not require `--privileged`, and does not mount the Docker socket.
+- [ ] `build-static-tests.yaml` still runs unchanged on the same triggers; nothing in the new pipeline replaces or short-circuits its jobs.
+- [ ] A deliberate breaking change in `chezmoi_config/dot_tool-versions` (e.g. a non-existent tool version) makes the new pipeline fail; reverting it makes it green again.
+- [ ] The base image pin and the Bats version pin both appear in Renovate's dashboard, and update PRs for either can be opened by Renovate without manual config tweaks.
+
+## Open Questions
+
+- Should the image be built and pushed to GHCR for sharing between the cron job and the per-PR job, or rebuilt from scratch in each job? The trade-off is registry maintenance versus build time.
+- For the second apply, is `chezmoi apply --verbose` parsing reliable enough to detect re-execution of `run_onchange_*` scripts, or do we need a chezmoi-native marker (e.g. comparing state hashes)? This influences whether the test depends on a CLI output format that could change between chezmoi releases.
+- Is a single-distro (Ubuntu LTS) baseline enough, or should the first iteration already include a second distro to prevent ubuntu-specific drift? Current decision: single-distro now, matrix later — revisit after the first three months of green runs.


### PR DESCRIPTION
## Summary

Land the `containerised-provisioning-tests` specification, which defines an end-to-end, container-isolated verification of the chezmoi provisioning path. This spec scaffolding was authored previously but never committed; it is landed here as its own change, decoupled from the planning-cascade work in #80 / #81.

## Changes

- Add `spec/containerised-provisioning-tests/{en,de}.md` — the bilingual spec: a Dockerfile-based test that runs `chezmoi init --apply` against the local working tree, asserts the on-disk "Provisioning post-conditions" via Bats, and verifies a second apply is a no-op.
- Add `spec/.spec-config.yml` — the spec-tree config (`canonical_language: en`, `languages: [en, de]`, `spec_root: spec`).
- Add `spec/README.md` — the spec index listing the new spec.

## Linked issues

None
Refs spec/containerised-provisioning-tests/

## Testing

- `task lint` (pre-commit: check-yaml, end-of-file-fixer, trailing-whitespace) — Passed on all files.
- `task test` (Vale) is a local, non-gating check; the German `de.md` translation trips the English Vale dictionary as a known, pre-existing pattern — not a CI gate (CI runs pre-commit + Trivy + chain-bench only).

## Risk / rollout notes

Documentation/spec only — no runtime code, dependencies, or migrations. The spec is `Status: draft`; it prescribes *what* the provisioning test must verify and under which constraints, but ships no Dockerfile, test code, or CI workflow — those are a follow-up implementation PR per the spec's own Non-Goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)