### PR TITLE
chore: remove vagrant from asdf plugins and tool-versions

### DIFF
--- a/chezmoi_config/dot_tool-versions
+++ b/chezmoi_config/dot_tool-versions
@@ -22,7 +22,6 @@ talhelper 3.1.13
 talosctl 1.13.6
 task 3.33.1
 terraform 1.15.8
-vagrant 2.3.4
 vale 3.0.1
 vendir 0.32.2
 yq 4.53.2

--- a/chezmoi_config/run_onchange_before_install-add-plugins.sh
+++ b/chezmoi_config/run_onchange_before_install-add-plugins.sh
@@ -39,7 +39,6 @@ asdfAddPluginIfNotExists talosctl
 asdfAddPluginIfNotExists task
 asdfAddPluginIfNotExists terraform
 asdfAddPluginIfNotExists terragrunt
-asdfAddPluginIfNotExists vagrant
 asdfAddPluginIfNotExists vale
 asdfAddPluginIfNotExists vault
 asdfAddPluginIfNotExists vendir


### PR DESCRIPTION
## Summary

Remove the vagrant CLI from workstation provisioning. This drops the asdf
plugin registration and its pinned version, so `chezmoi apply` no longer
installs vagrant on provisioned machines.

## Changes

- Remove `asdfAddPluginIfNotExists vagrant` from
  `chezmoi_config/run_onchange_before_install-add-plugins.sh`
- Remove `vagrant 2.3.4` from `chezmoi_config/dot_tool-versions`

## Linked issues

None

## Testing

- `task lint` (pre-commit: check-yaml, end-of-file-fixer, trailing-whitespace) — passed
- `git diff origin/develop...HEAD` — confirms only the two vagrant lines are removed

## Risk / rollout notes

Low. Changing `dot_tool-versions` re-triggers the asdf-install run_onchange
script on next apply. On already-provisioned machines the vagrant plugin and
version stay installed locally — asdf does not prune them; remove manually with
`asdf plugin remove vagrant` if desired.