### PR TITLE
feat(chezmoi): provision global GitHub MCP server via modify_ script

### DIFF
--- a/chezmoi_config/modify_dot_claude.json
+++ b/chezmoi_config/modify_dot_claude.json
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# chezmoi modify_ script for ~/.claude.json
+#
+# chezmoi pipes the current file contents to this script's stdin and replaces
+# the file with our stdout. We deliberately touch ONLY mcpServers.github and
+# preserve every other key untouched:
+#   - Claude Code's own churn (projects, caches, tips history)
+#   - secrets that must NEVER live in this repo (oauthAccount, userID, machineID)
+#   - any other MCP server already registered (e.g. reachy-mini)
+#
+# The GitHub MCP server is the remote, OAuth-authenticated variant, so the
+# config entry carries no secret. Authenticate once per machine by running
+# `/mcp` in a Claude Code session (opens a browser login); the resulting
+# credentials are stored in the system keychain / credential store, not here.
+#
+# python3 (a system binary) is used instead of jq on purpose: this modify_
+# script runs during `chezmoi apply` BEFORE the run_onchange_after asdf step
+# installs jq, so jq is not yet on PATH during a fresh bootstrap.
+
+set -e
+set -u
+set -o pipefail
+
+py="$(command -v python3 || command -v python || true)"
+if [ -z "$py" ]; then
+    echo "modify_dot_claude.json: no python interpreter found; leaving ~/.claude.json unchanged" >&2
+    cat
+    exit 0
+fi
+
+# NOTE: the program is passed via `-c` (an argv, not a heredoc). A heredoc
+# would occupy python's stdin and leave sys.stdin.read() empty, which would
+# collapse the whole file to just the github entry. With `-c`, stdin stays the
+# current ~/.claude.json that chezmoi piped in.
+"$py" -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+data = json.loads(raw) if raw else {}
+
+data.setdefault("mcpServers", {})
+data["mcpServers"]["github"] = {
+    "type": "http",
+    "url": "https://api.githubcopilot.com/mcp/",
+}
+
+# Match Claude Code’s own serialisation (2-space indent, raw UTF-8, no trailing
+# newline) so `chezmoi apply` only ever forces the github entry with no
+# cosmetic diff.
+json.dump(data, sys.stdout, indent=2, ensure_ascii=False)
+'


### PR DESCRIPTION
## Summary

Register the remote, OAuth-authenticated GitHub MCP server at user scope so it
is available in every provisioned workstation and project, without committing
any secret to the repo.

## Changes

- Add `chezmoi_config/modify_dot_claude.json`, a chezmoi `modify_` script that
  merges only `mcpServers.github` into the existing `~/.claude.json` and leaves
  every other key untouched (Claude Code state, secrets such as `oauthAccount`,
  and any already-registered MCP server like `reachy-mini`).
- Point the entry at the remote GitHub MCP endpoint
  (`https://api.githubcopilot.com/mcp/`) over HTTP with browser OAuth, so no PAT
  or Docker credentials live in the repo.
- Merge with `python3` rather than `jq`, since the `modify_` step runs during
  `chezmoi apply` before asdf installs jq on a fresh bootstrap.
- Match Claude Code's serialisation (2-space indent, raw UTF-8, no trailing
  newline) so `apply` only ever forces the `github` entry with no cosmetic diff.

## Linked issues

None

## Testing

- Ran the script against a frozen snapshot of `~/.claude.json`: only
  `mcpServers` changes, all 60 top-level keys preserved, existing `reachy-mini`
  server byte-identical, `github` added; transform verified idempotent.
- `chezmoi cat ~/.claude.json` (this repo as source, no apply) renders the
  merged file correctly.
- `pre-commit run --files chezmoi_config/modify_dot_claude.json` — check-yaml /
  end-of-file / trailing-whitespace pass.

## Risk / rollout notes

Low. The change is additive and preserves all existing keys (verified against a
snapshot). Because Claude Code rewrites `~/.claude.json` continuously,
`chezmoi diff` will often show the file as changed, but `apply` only ever forces
the `github` entry. OAuth login is per-machine and interactive (`/mcp` in a
Claude Code session); credentials are stored in the system keychain, not in the
repo.