### PR TITLE
chore(renovate): track asdf tools missing from the built-in allowlist

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,4 +9,56 @@
       '/chezmoi_config/dot_tool-versions/',
     ],
   },
+  // Tools not on Renovate's built-in asdf allowlist (see
+  // https://docs.renovatebot.com/modules/manager/asdf/). The asdf manager
+  // silently ignores them, so we pin each to its upstream GitHub releases
+  // via a custom manager. extractVersion strips the tag prefix so the value
+  // written back matches the bare semver used in dot_tool-versions.
+  customManagers: [
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
+      matchStrings: ['k9s (?<currentValue>\\S+)'],
+      depNameTemplate: 'derailed/k9s',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+      versioningTemplate: 'semver-coerced',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
+      matchStrings: ['jq (?<currentValue>\\S+)'],
+      depNameTemplate: 'jqlang/jq',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^jq-(?<version>.+)$',
+      versioningTemplate: 'semver-coerced',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
+      matchStrings: ['argo (?<currentValue>\\S+)'],
+      depNameTemplate: 'argoproj/argo-workflows',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+      versioningTemplate: 'semver-coerced',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
+      matchStrings: ['gopass (?<currentValue>\\S+)'],
+      depNameTemplate: 'gopasspw/gopass',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+      versioningTemplate: 'semver-coerced',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
+      matchStrings: ['vendir (?<currentValue>\\S+)'],
+      depNameTemplate: 'carvel-dev/vendir',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+      versioningTemplate: 'semver-coerced',
+    },
+  ],
 }


### PR DESCRIPTION
## Summary

Renovate's asdf manager only updates tools on its fixed supported-tooling
allowlist and silently ignores everything else. As a result k9s, jq, argo,
gopass, and vendir never received update PRs and drifted (k9s had to be
bumped by hand from 0.27.4 to 0.51.0). This adds custom managers so those
tools are tracked against their upstream GitHub releases.

## Changes

- Add a `customManagers` (regex) block to `renovate.json5` pinning k9s
  (`derailed/k9s`), jq (`jqlang/jq`), argo (`argoproj/argo-workflows`),
  gopass (`gopasspw/gopass`), and vendir (`carvel-dev/vendir`) to their
  `github-releases` datasource.
- Use `extractVersion` per tool to strip the tag prefix (`v` / `jq-`) so the
  version written back matches the bare semver format in `dot_tool-versions`.
- Use `semver-coerced` versioning so jq's `1.6` short pin resolves and
  gopass prereleases (`-rc`) are excluded.

## Linked issues

None

## Testing

- `renovate-config-validator` (Renovate 41.173.1): `Config validated successfully`
- `task lint` (pre-commit: check-yaml, end-of-file-fixer, trailing-whitespace): all passed

## Risk / rollout notes

Low. Config-only change; the existing `asdf` manager is untouched. Expect the
next Renovate run to open updates for the newly tracked tools — notably
`argo 3.4.5 → 4.x`, which is a major bump and should be reviewed before merge.
mc is intentionally left untracked (its `RELEASE.<timestamp>` scheme is not
sensibly versionable).