### PR TITLE
fix(chezmoi): authenticate global GitHub MCP server via PAT header

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ The local terminal is optimized with various extensions to further increase prod
 A reusable [go-task/task](https://github.com/go-task/task) collection for working with the installed tools.
 <!--taskfile-end-->
 
+### GitHub MCP server
+
+<!--github-mcp-start-->
+A global GitHub [MCP](https://modelcontextprotocol.io/) server is registered for every [Claude Code](https://www.claude.com/product/claude-code) project by merging a `github` entry into `~/.claude.json`. It authenticates with a GitHub Personal Access Token read from the `GITHUB_MCP_PAT` environment variable, so no secret is stored in this repository.
+
+Export the token **before** starting Claude Code — if the variable is unset, Claude Code fails to parse the configuration:
+
+```sh
+export GITHUB_MCP_PAT="$(gh auth token)"
+```
+
+Add that line to your shell startup file (for example `~/.zshrc`) so every session has it. The browser-based OAuth login (`claude mcp login`) is not usable here: the remote endpoint does not support OAuth dynamic client registration, which that flow requires.
+<!--github-mcp-end-->
+
 ## Usage
 
 ### Initial setup

--- a/chezmoi_config/modify_dot_claude.json
+++ b/chezmoi_config/modify_dot_claude.json
@@ -9,10 +9,16 @@
 #   - secrets that must NEVER live in this repo (oauthAccount, userID, machineID)
 #   - any other MCP server already registered (e.g. reachy-mini)
 #
-# The GitHub MCP server is the remote, OAuth-authenticated variant, so the
-# config entry carries no secret. Authenticate once per machine by running
-# `/mcp` in a Claude Code session (opens a browser login); the resulting
-# credentials are stored in the system keychain / credential store, not here.
+# The GitHub MCP server authenticates with a GitHub Personal Access Token passed
+# as an `Authorization: Bearer` header. The token itself is NOT stored here: the
+# header value is the literal placeholder `${GITHUB_MCP_PAT}`, which Claude Code
+# expands from the environment at connect time. Export GITHUB_MCP_PAT BEFORE
+# launching Claude Code (an unset placeholder makes Claude Code fail to parse the
+# config), e.g. `export GITHUB_MCP_PAT="$(gh auth token)"` — see the docs.
+#
+# Why a PAT and not the browser OAuth flow: the remote endpoint does not support
+# OAuth dynamic client registration (RFC 7591), which `claude mcp login` requires,
+# so the interactive browser login can never complete against this server.
 #
 # python3 (a system binary) is used instead of jq on purpose: this modify_
 # script runs during `chezmoi apply` BEFORE the run_onchange_after asdf step
@@ -58,6 +64,9 @@ data.setdefault("mcpServers", {})
 data["mcpServers"]["github"] = {
     "type": "http",
     "url": "https://api.githubcopilot.com/mcp/",
+    "headers": {
+        "Authorization": "Bearer ${GITHUB_MCP_PAT}",
+    },
 }
 
 # Match Claude Code’s own serialisation (2-space indent, raw UTF-8, no trailing

--- a/docs/de/configurations/github-mcp.md
+++ b/docs/de/configurations/github-mcp.md
@@ -1,0 +1,30 @@
+---
+title: GitHub MCP
+audience: [workstation-operator]
+content_mode: reference
+track: user-docs
+source_language: en
+last_updated: 2026-07-11
+---
+
+# GitHub MCP server
+
+{%
+   include-markdown "../../../README.md"
+   start="<!--github-mcp-start-->"
+   end="<!--github-mcp-end-->"
+%}
+
+The entry merged into `~/.claude.json` by `chezmoi_config/modify_dot_claude.json`:
+
+```json
+{
+  "type": "http",
+  "url": "https://api.githubcopilot.com/mcp/",
+  "headers": {
+    "Authorization": "Bearer ${GITHUB_MCP_PAT}"
+  }
+}
+```
+
+Claude Code expands `${GITHUB_MCP_PAT}` from the environment at connect time. Verify the connection with `claude mcp list`; the `github` server should report `✔ Connected`.

--- a/docs/en/configurations/github-mcp.md
+++ b/docs/en/configurations/github-mcp.md
@@ -1,0 +1,29 @@
+---
+title: GitHub MCP
+audience: [workstation-operator]
+content_mode: reference
+track: user-docs
+last_updated: 2026-07-11
+---
+
+# GitHub MCP server
+
+{%
+   include-markdown "../../../README.md"
+   start="<!--github-mcp-start-->"
+   end="<!--github-mcp-end-->"
+%}
+
+The entry merged into `~/.claude.json` by `chezmoi_config/modify_dot_claude.json`:
+
+```json
+{
+  "type": "http",
+  "url": "https://api.githubcopilot.com/mcp/",
+  "headers": {
+    "Authorization": "Bearer ${GITHUB_MCP_PAT}"
+  }
+}
+```
+
+Claude Code expands `${GITHUB_MCP_PAT}` from the environment at connect time. Verify the connection with `claude mcp list`; the `github` server should report `✔ Connected`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ plugins:
             Home: Start
             References: Referenzen
             Package manager (asdf): Paketmanager (asdf)
+            GitHub MCP server: GitHub-MCP-Server
 markdown_extensions:
   - pymdownx.inlinehilite:
   - pymdownx.superfences:
@@ -37,3 +38,4 @@ nav:
     - Git: configurations/git.md
     - zsh: configurations/zsh.md
     - Taskfile: configurations/taskfile.md
+    - GitHub MCP server: configurations/github-mcp.md


### PR DESCRIPTION
## Summary

Fix the global GitHub MCP server provisioned in #90, which always reported
"Failed to connect": the remote endpoint (api.githubcopilot.com/mcp/) does not
support OAuth dynamic client registration, so the `claude mcp login` browser
flow can never complete. Switch to Personal Access Token authentication via an
environment-expanded header, and document the setup.

## Changes

- Inject an `Authorization: Bearer ${GITHUB_MCP_PAT}` header into the `github`
  entry written by `chezmoi_config/modify_dot_claude.json`; Claude Code expands
  the variable from the environment at connect time, so no secret is stored.
- Rewrite the modify_ script's header comment (OAuth rationale → PAT rationale).
- Add a "GitHub MCP server" feature section to `README.md` documenting the
  required `export GITHUB_MCP_PAT="$(gh auth token)"` step before launching
  Claude Code.
- Add `docs/en` and `docs/de` pages for the GitHub MCP server and register the
  nav entry (with German label) in `mkdocs.yml`.

## Linked issues

Refs #90

## Testing

- `GITHUB_MCP_PAT="$(gh auth token)" claude mcp list` -> `github ... Connected`.
- Rebased onto develop (incl. #92 interpreter change); ran the modify_ script on
  sample input -> valid JSON, foreign keys and the reachy-mini server preserved,
  header set to `Bearer ${GITHUB_MCP_PAT}`.
- `mkdocs build --strict` -> passes (nav translates 4 elements to `de`).
- `task lint` -> passes (check-yaml, end-of-files, trailing-whitespace).

## Risk / rollout notes

Low risk. Operators must export `GITHUB_MCP_PAT` before starting Claude Code -
if unset, Claude Code fails to parse the config; this is documented in the
README and docs pages. No secret is committed to the repository.