### PR TITLE
docs: revise README and docs for the workstation-operator audience

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 _extends: gh-plumbing:.github/commons-settings.yml
 repository:
   name: workstation
-  description: Local Workstation Configuration
+  description: 'chezmoi source tree that provisions a developer workstation: asdf-pinned CLI tools, a baseline git config, zsh plugins, and a reusable Taskfile collection.'
   homepage: https://nolte.github.io/workstation/
-  topics: templating, dotfile, workstation
+  topics: chezmoi, asdf, dotfile, templating, workstation

--- a/README.md
+++ b/README.md
@@ -5,33 +5,75 @@
 [![Auto-merge](https://github.com/nolte/workstation/actions/workflows/automerge.yaml/badge.svg)](https://github.com/nolte/workstation/actions/workflows/automerge.yaml)
 
 <!--intro-start-->
-This project uses [chezmoi](https://www.chezmoi.io/) to provision developer workstations from a single source tree: asdf-pinned command-line interface (CLI) tool versions, a baseline git configuration, zsh plugins, and a reusable Taskfile collection. It targets developers who want a reproducible, idempotent setup across machines.
+A [chezmoi](https://www.chezmoi.io/) source tree that provisions a developer workstation from a single `chezmoi init --apply`: asdf-pinned command-line interface (CLI) tool versions, a baseline git configuration, zsh plugins, and a reusable Taskfile collection. For developers who want a reproducible, idempotent setup across machines.
 <!--intro-end-->
 
 ## Purpose
 
 - Provision a developer workstation deterministically with [chezmoi](https://www.chezmoi.io/): one `chezmoi init --apply` brings a fresh machine to a known state.
-- Pin CLI tool versions through [asdf](https://asdf-vm.com/) so every machine resolves the same versions, kept current by Renovate.
+- Pin CLI tool versions through [asdf](https://asdf-vm.com/) so every machine resolves the same versions, kept current by [Renovate](https://docs.renovatebot.com/).
 - Ship a baseline git configuration, zsh plugins, and a reusable [Taskfile](https://taskfile.dev/) collection without per-machine hand-editing.
-- This repository targets the workstation operator applying it to their own machine — not application code or project scaffolding.
+- Intended for the workstation operator applying it to their own machine — not application code or project scaffolding.
+
+## Usage
+
+Requires [chezmoi](https://www.chezmoi.io/install/) installed on the target machine.
+
+### Initial setup
+
+Create a local configuration at `~/.config/chezmoi/chezmoi.toml` with the data required for file generation:
+
+```toml
+[data]
+    git_email = "<EmailForGitConfig>"
+    git_name  = "<NameForGitConfig>"
+```
+
+See the [chezmoi configuration reference](https://www.chezmoi.io/reference/configuration-file/) for details. Then use this repository as your [dotfile](https://www.chezmoi.io/user-guide/setup/) source:
+
+```sh
+chezmoi init --apply --verbose https://github.com/nolte/workstation.git
+```
+
+### Day-to-day
+
+Pull the latest changes and apply them, or preview local edits before applying:
+
+```sh
+chezmoi update   # pull latest from this repo, then apply
+chezmoi apply    # render templates and write files into $HOME
+chezmoi diff     # preview changes before applying
+```
+
+See the [chezmoi quick-start guide](https://www.chezmoi.io/quick-start/#start-using-chezmoi-on-your-current-machine) for more commands.
+
+### Local development
+
+Repo-level checks run from the repository root via the root `Taskfile.yml` (needs the [go-task](https://taskfile.dev/) CLI on your `PATH`):
+
+```sh
+task lint        # run pre-commit across all files
+task test        # lint prose with Vale (nolte/vale-style)
+task docs:build  # build the documentation site (mkdocs build --strict)
+```
 
 ## Features
 
 ### Package manager (asdf)
 <!--asdf-start-->
-Manage a set of extra repositories, not managed at [asdf-vm/asdf-plugins](https://github.com/asdf-vm/asdf-plugins/tree/master/plugins)
+Adds asdf plugin repositories that aren't listed in the official [asdf-vm/asdf-plugins](https://github.com/asdf-vm/asdf-plugins/tree/master/plugins) index.
 <!--asdf-end-->
 
 ### Git
 
 <!--git-start-->
-The basic Git configurations such as default branch are pre-configured.
+Sets basic Git defaults, such as the default branch, out of the box.
 <!--git-end-->
 
 ### zsh
 
 <!--zsh-start-->
-The local terminal is optimized with various extensions to further increase productivity.
+Adds zsh plugins that make the interactive shell faster to work in.
 <!--zsh-end-->
 
 ### Taskfile
@@ -43,47 +85,16 @@ A reusable [go-task/task](https://github.com/go-task/task) collection for workin
 ### GitHub MCP server
 
 <!--github-mcp-start-->
-A global GitHub [MCP](https://modelcontextprotocol.io/) server is registered for every [Claude Code](https://www.claude.com/product/claude-code) project by merging a `github` entry into `~/.claude.json`. It authenticates with a GitHub Personal Access Token read from the `GITHUB_MCP_PAT` environment variable, so no secret is stored in this repository.
+Registers a global GitHub [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for every [Claude Code](https://www.claude.com/product/claude-code) project by merging a `github` entry into `~/.claude.json`. It authenticates with a GitHub Personal Access Token read from the `GITHUB_MCP_PAT` environment variable, so no secret is stored in this repository.
 
-Export the token **before** starting Claude Code — if the variable is unset, Claude Code fails to parse the configuration:
+Export the token **before** starting Claude Code — if the variable is unset, Claude Code fails to parse the configuration. The snippet below reads it from the authenticated [GitHub CLI](https://cli.github.com/) (run `gh auth login` first):
 
 ```sh
 export GITHUB_MCP_PAT="$(gh auth token)"
 ```
 
-Add that line to your shell startup file (for example `~/.zshrc`) so every session has it. The browser-based OAuth login (`claude mcp login`) is not usable here: the remote endpoint does not support OAuth dynamic client registration, which that flow requires.
+Add that line to your shell startup file (for example `~/.zshrc`) so every session has it. The browser-based OAuth login (`claude mcp login`) is not usable here, because that flow requires OAuth dynamic client registration, which the remote endpoint doesn't support.
 <!--github-mcp-end-->
-
-## Usage
-
-### Initial setup
-
-Requires [chezmoi](https://www.chezmoi.io/install/) installed on the target machine.
-
-Before you can start, create a local configuration at `~/.config/chezmoi/chezmoi.toml` with the information required for file generation:
-
-```toml
-[data]
-    git_email = "<EmailForGitConfig>"
-    git_name  = "<NameForGitConfig>"
-```
-
-See the [chezmoi configuration reference](https://www.chezmoi.io/reference/configuration-file/) for details. Use this repository as your [dotfile](https://www.chezmoi.io/user-guide/setup/) source:
-
-```sh
-chezmoi init --apply --verbose https://github.com/nolte/workstation.git
-```
-
-### Day-to-day
-
-Pull the latest changes and apply them, or preview and apply local edits:
-
-```sh
-chezmoi update
-chezmoi apply
-```
-
-See the [chezmoi quick-start guide](https://www.chezmoi.io/quick-start/#start-using-chezmoi-on-your-current-machine) for more commands.
 
 ## Structure
 
@@ -105,16 +116,6 @@ Everything outside `chezmoi_config/` is repository tooling and is not delivered 
 - [nolte/gh-plumbing](https://github.com/nolte/gh-plumbing) — reusable GitHub workflows and Probot/Renovate presets this repository extends.
 - [nolte/taskfiles](https://github.com/nolte/taskfiles) — the reusable Taskfile collection fetched onto provisioned machines.
 - [nolte/vale-style](https://github.com/nolte/vale-style) — the Vale prose-style package used to lint this repository's docs.
-
-## Development
-
-Repo-level checks run from the repository root via the root `Taskfile.yml`:
-
-- `task lint` — run `pre-commit` across all files.
-- `task test` — lint prose with Vale against the shared `nolte/vale-style` rules.
-- `task docs:build` — build the documentation site with `mkdocs build --strict`.
-
-The `develop` branch is the integration branch; `main` is fast-forwarded only on release publish.
 
 ## Status
 

--- a/docs/de/configurations/github-mcp.md
+++ b/docs/de/configurations/github-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub MCP
+title: GitHub MCP server
 audience: [workstation-operator]
 content_mode: reference
 track: user-docs
@@ -15,7 +15,7 @@ last_updated: 2026-07-11
    end="<!--github-mcp-end-->"
 %}
 
-The entry merged into `~/.claude.json` by `chezmoi_config/modify_dot_claude.json`:
+Der Eintrag, den `chezmoi_config/modify_dot_claude.json` in `~/.claude.json` einfügt:
 
 ```json
 {
@@ -27,4 +27,4 @@ The entry merged into `~/.claude.json` by `chezmoi_config/modify_dot_claude.json
 }
 ```
 
-Claude Code expands `${GITHUB_MCP_PAT}` from the environment at connect time. Verify the connection with `claude mcp list`; the `github` server should report `✔ Connected`.
+Claude Code löst `${GITHUB_MCP_PAT}` beim Verbindungsaufbau aus der Umgebung auf. Prüfe die Verbindung mit `claude mcp list`; der `github`-Server sollte `✔ Connected` melden.

--- a/docs/en/configurations/github-mcp.md
+++ b/docs/en/configurations/github-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub MCP
+title: GitHub MCP server
 audience: [workstation-operator]
 content_mode: reference
 track: user-docs

--- a/project/requirements/revise-readme-and-docs.md
+++ b/project/requirements/revise-readme-and-docs.md
@@ -1,0 +1,128 @@
+# Requirements — Revise README.md and the MkDocs docs tree
+
+<!--
+Produced via the `requirements-elicit` skill, following
+spec/project/requirements-elicitation/ (canonical source read from the
+upstream nolte-shared plugin at
+/home/nolte/repos/github/claude-shared/spec/project/requirements-elicitation/en.md;
+the spec is not yet vendored into this repo's spec/ tree — see the open risk
+below and the precedent set by project/requirements/claude-json-interpreter.md).
+`c_d` is an uncertainty proxy (self-consistency-derived), not a calibrated
+probability. A requirement is `confirmed` only after an explicit teach-back or
+an authoritative operator answer.
+-->
+
+## Bounded context
+
+- **What:** Revise `README.md` and the MkDocs docs tree (`docs/en`, `docs/de`) so
+  they are current, spec-conformant (`readme-structure`, `mkdocs-structure`),
+  readable, and DE/EN-complete. Concretely: a **Quick-start command section** that
+  leads with the chezmoi lifecycle, an **audience-appropriate intro**, and a
+  **verified list of portfolio (related-repository) dependencies**. Approach:
+  audit-first, then revise from the findings.
+- **For whom:** The **operator-as-adopter** — a developer (including the future
+  maintainer) who applies this repository to a fresh machine via
+  `chezmoi init --apply`. The docs lead with the provisioning path and are
+  self-onboarding; contributor / repo-maintenance material stays secondary.
+- **Out of scope (confirmed):** Moving any content out of `chezmoi_config/`
+  (the chezmoi source tree per `.chezmoiroot`); editing target-machine-delivered
+  content or provisioning logic; the generated `~/taskfile.yaml`. This branch
+  touches repo-level docs surfaces only (`README.md`, `docs/**`, `mkdocs.yml`
+  nav) plus the GitHub repo metadata (topics + description).
+
+## Understanding KPI
+
+- Thresholds: `τ_low = 0.4`, `τ_high = 0.8`, self-consistency `k = 2`, question budget = `5` (spec defaults; unchanged)
+- `U_gate = min_d c_d` over required dimensions = **0.82**
+- Termination: `saturation` — the four binding, specification-uncertain
+  decisions (audience, key-command shape/placement, DE/EN parity target, GitHub
+  metadata scope) were lifted by authoritative operator answers; the remaining
+  dimensions are evidence-backed by the researched plan (`.resume/revise-readme-and-docs/plan.md`),
+  `CLAUDE.md`, and the verified repo sources. No remaining candidate question has
+  positive net EVPI. The one item that previously held `edge_cases` at exactly
+  `τ_high` (Quick-start-vs-Purpose ordering) was resolved against the
+  `readme-structure` audit; the binding dimension is now `acceptance_criteria`
+  (0.82), whose remaining slack is verification-time, not understanding, gap.
+
+### Gap matrix
+
+| Dimension | Applicable | `c_d` | Uncertainty source | Evidence event |
+|---|---|---|---|---|
+| `functional` | yes | 0.88 | interpretation | Operator answers (audience = adopter; Quick-start section leading with chezmoi lifecycle); plan §1/§4; teach-back on audience + Quick-start confirmed |
+| `non_functional` | yes | 0.86 | specification | Plan §5 invariants (`readme-structure` order + ≤200-line budget, `mkdocs build --strict`, lektorat/Vale); `CLAUDE.md` |
+| `constraints` | yes | 0.90 | interpretation | `CLAUDE.md` + plan §5: `.chezmoiroot`=`chezmoi_config`, include sentinels, requirements-file sync, Vale local-only/non-gating |
+| `domain_objects` | yes | 0.88 | interpretation | Enumerated & verified: `README.md`, `docs/{en,de}`, `mkdocs.yml` nav, related repos, GitHub topics/description |
+| `actors` | yes | 0.85 | specification | Authoritative operator answer "Operator-as-adopter" + teach-back confirmed |
+| `acceptance_criteria` | yes | 0.82 | specification | Operator answers + plan §4 step 7: `task docs:build --strict` green, EN Vale/lektorat pass, DE structural parity, metadata aligned, PR handoff |
+| `edge_cases` | yes | 0.85 | interpretation | `k=2` self-consistency: divergent break-modes (structural conflict / translation drift / sentinel breakage / req-file desync) converge to a known, enumerable set; the Quick-start-vs-Purpose conflict is now resolved against `readme-structure` (R1/R4) |
+| `scope_boundaries` | yes | 0.85 | specification | Operator answer "GitHub metadata: check + align, in this PR"; out-of-scope set confirmed in bounded context |
+
+## Requirements
+
+- **R1** — The revised `README.md` SHALL lead with the chezmoi lifecycle
+  (`init --apply` → `update`/`apply`, `diff`) by keeping `## Purpose` tight and
+  placing `## Usage` (commands up front) immediately after it — before the
+  optional `## Features` section. It SHALL NOT introduce a commands section above
+  `## Purpose`, so the `readme-structure` required-section order is preserved.
+  - _dimension_: `functional` · _status_: `confirmed` · _source_: "Purpose führt, Usage-Befehle vor" (revised from the earlier "Quick-Start-Sektion oben" after the `readme-structure` audit surfaced the ordering conflict; see R4)
+- **R2** — The `README.md` and docs SHALL be written for the operator-as-adopter (a
+  developer, including the future maintainer, applying this repo to a fresh
+  machine), leading with the provisioning path and staying self-onboarding, WHILE
+  contributor / repo-maintenance material remains secondary.
+  - _dimension_: `actors` · _status_: `confirmed` · _source_: "Operator-as-adopter"
+- **R3** — The `Related repositories` list SHALL enumerate exactly the nolte-portfolio
+  dependencies actually referenced by the repo — `nolte/gh-plumbing`,
+  `nolte/taskfiles`, `nolte/vale-style` — verified against `.chezmoiexternal.toml`,
+  the `renovate.json5` `extends`, and `.vale.ini`; third-party zsh plugins SHALL be
+  excluded from that list.
+  - _dimension_: `domain_objects` · _status_: `confirmed` · _source_: operator goal §1 "verified, up-to-date list of portfolio dependencies" + verified sources
+- **R4** — The revised `README.md` SHALL conform to `readme-structure`: required
+  sections in order (`Purpose` → `Usage` → `Structure` → `Related repositories` →
+  `Status` → `License`), `Purpose` as the first `##`, the ≤200-line budget, absolute
+  portfolio links, and a relative `LICENSE` link. The ordering conflict raised by
+  R1's earlier form was resolved in favour of the spec (see R1) — no deviation
+  remains.
+  - _dimension_: `non_functional` · _status_: `confirmed` · _source_: `readme-structure` en.md audit + operator decision "Purpose führt, Usage-Befehle vor"
+- **R5** — EN SHALL be canonical: WHEN `docs/en` is revised, `docs/de` SHALL be brought
+  to a faithful translation preserving structural parity (same pages, same nav),
+  and Vale SHALL NOT be chased to green on `de.md` at the cost of correct German.
+  - _dimension_: `functional` / `edge_cases` · _status_: `confirmed` · _source_: "EN kanonisch, DE als Übersetzung"
+- **R6** — The pass SHALL check the GitHub repo **topics** and **description** against
+  the revised tagline/scope and align them, landing the change at the correct owner
+  (`.github/settings.yml` `_extends` target, or directly on the repo if set there),
+  as part of this PR.
+  - _dimension_: `scope_boundaries` · _status_: `confirmed` · _source_: "Ja, prüfen + angleichen"
+- **R7** — WHEN the revision is complete, `task docs:build` (`--strict`) SHALL pass, a
+  lektorat + Vale pass SHALL be run on the revised EN prose, and the work SHALL hand
+  off to `pull-request-create`.
+  - _dimension_: `acceptance_criteria` · _status_: `confirmed` · _source_: plan §4 step 7–8 (adopted approach)
+- **R8** — The revision SHALL keep every `<!--X-start-->`/`<!--X-end-->` include
+  sentinel intact, SHALL NOT move content out of `chezmoi_config/`, and SHALL keep
+  `docs/requirements.txt` and `chezmoi_config/requirements-mkdocs.txt` in sync if
+  either is touched.
+  - _dimension_: `constraints` · _status_: `confirmed` · _source_: `CLAUDE.md` + plan §5 invariants
+- **R9** — Before editing, the pass SHALL run the read-only audits (`readme-structure`
+  audit, `docs-freshness-checker`, an audience check, then `lektorat`/Vale on the
+  revised text) and collect findings under `.audits/`.
+  - _dimension_: `acceptance_criteria` (approach) · _status_: `assumed` · _source_: plan §3/§4 (audit-first design; not separately re-confirmed in interview)
+
+## Surviving assumptions / open risks
+
+- **Spec not vendored locally.** The requirements-elicitation methodology spec is
+  read from the upstream nolte-shared plugin, not from this repo's `spec/` tree
+  (only `spec/containerised-provisioning-tests/` exists). Same caveat the prior
+  `claude-json-interpreter.md` artifact recorded; see memory
+  `workstation-planning-vale-caveats`.
+- **R1/R4 resolved (was an open risk).** The `readme-structure` audit confirmed a
+  `## Quick start` heading above `## Purpose` would break the required-section
+  order; the operator chose the spec-conformant realisation ("Purpose führt,
+  Usage-Befehle vor" — tight `Purpose`, `Usage` with commands up front directly
+  after it). No deviation remains.
+- **R9 is `assumed`.** The audit-first sequence and exact auditor set come from the
+  plan, not an explicit operator confirmation; safe to proceed but re-openable.
+- **GitHub metadata ownership (R6).** Topics/description may be owned by the
+  `.github/settings.yml` `_extends: gh-plumbing:` pointer (Probot settings app) or
+  set directly on the repo — the correct write location is only determined during
+  execution (`gh repo view` + inspecting the extends target).
+- **DE Vale (R5).** `de.md` content can trip the local, non-gating Vale run; German
+  correctness wins over Vale-green (see `workstation-planning-vale-caveats`).


### PR DESCRIPTION
## Summary

Revise the README and MkDocs docs to lead with the chezmoi provisioning path for the workstation-operator (adopter) audience, verify the related-repository list, and align the GitHub repository metadata. Driven by a confidence-scored requirements-elicit artifact and an audit-first pass.

## Changes

- Lead with the chezmoi lifecycle: pull `## Usage` ahead of `## Features` and add `chezmoi diff` to the day-to-day loop.
- Fold the former `## Development` section into a `### Local development` subsection under `## Usage` (per readme-structure), noting the go-task prerequisite.
- Tighten the adopter intro; keep all `<!--…-->` include sentinels intact so the docs includes stay valid.
- Apply lektorat fixes: expand "Model Context Protocol (MCP)", link Renovate, state the go-task / `gh` CLI prerequisites, and rewrite the Features blurbs in active voice.
- Align `.github/settings.yml` `description` and `topics` with the tagline (add `chezmoi`, `asdf`).
- Fix the github-mcp page `title` frontmatter (EN + DE) and translate the untranslated DE trailing prose.
- Add the requirements-elicit artifact `project/requirements/revise-readme-and-docs.md`.

## Linked issues

None

## Testing

- `task docs:build` (`mkdocs build --strict`) — green.
- `vale README.md docs/en/` — 0 errors, 0 warnings, 0 suggestions (docs/de trips only on pre-existing German false positives; Vale is local-only / non-gating here).
- `task lint` (pre-commit: check-yaml, end-of-file-fixer, trailing-whitespace) — green.
- README = 126 lines (≤200 budget); all six include sentinels present.

## Risk / rollout notes

Low. Documentation and repository-metadata only — no target-machine (`chezmoi_config/`) content changed. The `.github/settings.yml` description/topics update lands via the Probot settings app on merge.