### PR TITLE
feat(chezmoi): provision skaffold via asdf

### DIFF
--- a/chezmoi_config/dot_tool-versions
+++ b/chezmoi_config/dot_tool-versions
@@ -18,6 +18,7 @@ mc RELEASE.2020-11-25T23-04-07Z
 packer 1.15.4
 python 3.14.6
 shfmt 3.13.1
+skaffold 2.23.0
 talhelper 3.1.13
 talosctl 1.13.6
 task 3.33.1

--- a/chezmoi_config/run_onchange_before_install-add-plugins.sh
+++ b/chezmoi_config/run_onchange_before_install-add-plugins.sh
@@ -34,6 +34,7 @@ asdfAddPluginIfNotExists packer
 asdfAddPluginIfNotExists python
 asdfAddPluginIfNotExists shellcheck
 asdfAddPluginIfNotExists shfmt
+asdfAddPluginIfNotExists skaffold
 asdfAddPluginIfNotExists talhelper
 asdfAddPluginIfNotExists talosctl
 asdfAddPluginIfNotExists task


### PR DESCRIPTION
## Summary

Provision skaffold as an asdf-managed CLI tool on workstations. Adds the asdf plugin and pins version 2.23.0 so `chezmoi apply` installs it.

## Changes

- Register the `skaffold` asdf plugin in `run_onchange_before_install-add-plugins.sh`
- Pin `skaffold 2.23.0` in `dot_tool-versions`

## Linked issues

None

## Testing

- `task lint` — pre-commit hooks (check-yaml, end-of-file-fixer, trailing-whitespace) pass
- `git diff origin/develop...HEAD` — verified both files change, entries sorted alphabetically after `shfmt`

## Risk / rollout notes

None. Additive tool provisioning; Renovate already tracks dot_tool-versions and will keep the version current.