### PR TITLE
chore(asdf): bump Vale to 3.15.2 and track vale, chezmoi, task in Renovate

### DIFF
--- a/chezmoi_config/dot_tool-versions
+++ b/chezmoi_config/dot_tool-versions
@@ -23,6 +23,6 @@ talhelper 3.1.15
 talosctl 1.13.7
 task 3.33.1
 terraform 1.15.8
-vale 3.0.1
+vale 3.15.2
 vendir 0.46.0
 yq 4.53.3

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,8 @@
   // silently ignores them, so we pin each to its upstream GitHub releases
   // via a custom manager. extractVersion strips the tag prefix so the value
   // written back matches the bare semver used in dot_tool-versions.
+  // mc is the one deliberate exception: its RELEASE.<timestamp> scheme is not
+  // sensibly versionable, so it stays untracked and is bumped by hand.
   customManagers: [
     {
       customType: 'regex',
@@ -56,6 +58,36 @@
       managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
       matchStrings: ['vendir (?<currentValue>\\S+)'],
       depNameTemplate: 'carvel-dev/vendir',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+      versioningTemplate: 'semver-coerced',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
+      matchStrings: ['vale (?<currentValue>\\S+)'],
+      depNameTemplate: 'errata-ai/vale',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+      versioningTemplate: 'semver-coerced',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
+      matchStrings: ['chezmoi (?<currentValue>\\S+)'],
+      depNameTemplate: 'twpayne/chezmoi',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+      versioningTemplate: 'semver-coerced',
+    },
+    {
+      // go-task publishes a rolling `nightly` release alongside its tags; it
+      // carries GitHub's prerelease flag, so Renovate's default ignoreUnstable
+      // keeps it out of the update stream.
+      customType: 'regex',
+      managerFilePatterns: ['/chezmoi_config/dot_tool-versions/'],
+      matchStrings: ['task (?<currentValue>\\S+)'],
+      depNameTemplate: 'go-task/task',
       datasourceTemplate: 'github-releases',
       extractVersionTemplate: '^v(?<version>.+)$',
       versioningTemplate: 'semver-coerced',


### PR DESCRIPTION
## Summary

Bump the asdf-managed Vale pin (`chezmoi_config/dot_tool-versions`) from 3.0.1
to 3.15.2, matching the CI-pinned version in nolte/claude-shared
(claude-shared#526), and fix the root cause of the drift: Renovate never saw
the `vale` entry at all.

Renovate's asdf manager only updates tools on its built-in allowlist
(`lib/modules/manager/asdf/upgradeable-tooling.ts`) and silently ignores
everything else — no error, no dashboard entry. #91 closed that gap for k9s,
jq, argo, gopass, and vendir, but the inventory missed `vale`, `chezmoi`, and
`task`, which is why the Vale pin sat at 3.0.1 for so long.

## Changes

- `chezmoi_config/dot_tool-versions`: `vale 3.0.1` → `vale 3.15.2`. On the next
  `chezmoi apply`, provisioned workstations install Vale 3.15.2 via asdf.
- `renovate.json5`: add a regex custom manager for `vale` (`errata-ai/vale`),
  `chezmoi` (`twpayne/chezmoi`), and `task` (`go-task/task`), each against its
  upstream `github-releases` datasource with `extractVersion` stripping the
  `v` prefix — same shape as the existing five entries.
- `renovate.json5`: record in the comment why `mc` stays deliberately
  untracked (`RELEASE.<timestamp>` is not sensibly versionable).

go-task publishes a rolling `nightly` release alongside its tags. It carries
GitHub's `prerelease` flag, so Renovate's default `ignoreUnstable` keeps it out
of the update stream; no extra filtering needed.

## Linked issues

None

## Testing

- `renovate-config-validator` (Renovate 43.281.0): `Config validated successfully`
- Verified each new `matchStrings` regex matches exactly one line in
  `dot_tool-versions` and captures the intended version (`vale 3.15.2`,
  `chezmoi 2.40.0`, `task 3.33.1`).
- Confirmed the latest upstream releases all carry the expected `v` tag prefix
  (`v3.15.2`, `v2.71.1`, `v3.52.0`).
- `pre-commit run --all-files` (check-yaml, end-of-file-fixer,
  trailing-whitespace): all passed.

## Risk / rollout notes

Tooling and config only. The Vale bump takes effect on the next
`chezmoi apply` + `asdf install` per workstation. Expect the next Renovate run
to open catch-up PRs for the newly tracked tools — `chezmoi 2.40.0 → 2.71.x`
and `task 3.33.1 → 3.52.x` are sizeable minor jumps and should be reviewed
before merge. Pairs with claude-shared#526 (CI bump plus the prose fixes 3.15.2
newly enforces).